### PR TITLE
新規登録時の目次ページ追加

### DIFF
--- a/app/controllers/sign_up_controller.rb
+++ b/app/controllers/sign_up_controller.rb
@@ -4,7 +4,7 @@ class SignUpController < ApplicationController
   end
   
   def step1
-
+    
   end
   
   def step2(name:, email:, password:, password_confirmation:)

--- a/app/views/sign_up/index.html.erb
+++ b/app/views/sign_up/index.html.erb
@@ -1,1 +1,6 @@
 <h2>新規登録</h2>
+<%= link_to 'メールアドレスで登録', sign_up_step1_path %>
+<%= link_to 'LINEで登録' , user_line_omniauth_authorize_path , method: :post%>
+<%= link_to 'googleで登録', user_google_oauth2_omniauth_authorize_path, method: :post %>
+<p>アカウントをお持ちの方</p>
+<%= link_to 'ログイン', sign_in_index_path %>

--- a/app/views/sign_up/step1.html.erb
+++ b/app/views/sign_up/step1.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: step2_sign_up_index_path, method: :get ,local: true do |f| %>
+<%= form_with url: sign_up_step2_path, method: :get ,local: true do |f| %>
   <div class="form-group">
     <%= f.label :name, '名前' %><br />
     <%= f.text_field :name, autocomplete: 'name', maxlength:'15', required: true %>

--- a/app/views/sign_up/step2.html.erb
+++ b/app/views/sign_up/step2.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: sign_up_index_path, local: true do |f| %>
+<%= form_with url: sign_up_create_path, local: :true do |f| %>
   <div class="form-group">
     <%= f.label :confirmation_code, '認証コード' %><br />
     <%= f.number_field :confirmation_code %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,13 @@
 Rails.application.routes.draw do
   root 'homes#top'
-  devise_for :users, controllers: { 
+  devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
-  resources :sign_up do
-    collection do
-      get 'step1'
-      get 'step2'
-      get 'done'
-    end
-  end
-  get 'sites/index', to: 'sites#index'
+  get 'sign_up/index'
+  get 'sign_up/step1'
+  get 'sign_up/step2'
+  get 'sign_up/done'
+  post 'sign_up/create'
+  get 'sites/index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
- 目的
ユーザーが新規登録をするときにどの種類で登録をするかを選ぶためのページ追加

- 変更点
   - sign_up/index.html.erb
      - 各新規登録へのリンクを設置
   
   - ルーティング変更（ルーティング変更に伴ったリンクパスも変更）