### PR TITLE
認証コード再送信機能追加

### DIFF
--- a/app/controllers/sign_up_controller.rb
+++ b/app/controllers/sign_up_controller.rb
@@ -33,6 +33,11 @@ class SignUpController < ApplicationController
 
   end
 
+  def resend_confirmation_code
+    create_and_send_confirmation_code(email: session[:email], name: session[:name])
+    render :step2, notice: '確認コードを再送しました'
+  end
+
 
   private
 

--- a/app/views/sign_up/step2.html.erb
+++ b/app/views/sign_up/step2.html.erb
@@ -7,3 +7,6 @@
     <%= f.submit '認証' %>
   </div>
 <% end %>
+<p>メールが届かない場合</p>
+<!-- 2分に一回押せるようにする -->
+<%= link_to '再送する', sign_up_resend_confirmation_code_path%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get 'sign_up/step1'
   get 'sign_up/step2'
   get 'sign_up/done'
+  get 'sign_up/resend_confirmation_code'
   post 'sign_up/create'
   get 'sites/index'
   get 'sites/new'


### PR DESCRIPTION
## 目的
ユーザー登録時に認証コードメールが届かないとき、再送できるように機能を追加

## 変更点
- sign_up_controller
   - resend_confirmation_code
   
- step2.html.erb
   - 再送リンク追加
   
- routes.rb
   - 再送用ルート