### PR TITLE
現場メモ作成機能（step1）追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,4 @@ gem "one_time_password"
 gem 'devise-i18n'
 gem 'rails-i18n'
 gem "jquery-rails"
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.12.0)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
@@ -309,6 +311,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  enum_help
   jbuilder
   jquery-rails
   listen

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -5,7 +5,7 @@ class SiteMemosController < ApplicationController
   end
 
   def new_step1(site_id:)
-
+    @site = Site.find(site_id)
   end
 
   def form_switcher

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -3,4 +3,12 @@ class SiteMemosController < ApplicationController
     @site = Site.find(site_id)
     @construction_materials = @site.construction_materials
   end
+
+  def new_step1(site_id:)
+
+  end
+
+  def form_switcher
+    
+  end
 end

--- a/app/models/construction_material.rb
+++ b/app/models/construction_material.rb
@@ -1,3 +1,5 @@
 class ConstructionMaterial < ApplicationRecord
+  enum kind:{inner_sash: 0}
+
   belongs_to :site
 end

--- a/app/views/site_memos/index.html.erb
+++ b/app/views/site_memos/index.html.erb
@@ -18,3 +18,4 @@
 <% else %>
   <p>メモはありません</p>
 <% end %>
+<%= link_to 'メモ追加', site_memos_new_step1_path(@site.id) %>

--- a/app/views/site_memos/new_step1.html.erb
+++ b/app/views/site_memos/new_step1.html.erb
@@ -3,7 +3,10 @@
     <%= f.label :kind, '施工内容' %>
     <%= f.select :kind, ConstructionMaterial.kinds.keys.map{ |k| [I18n.t("enums.construction_material.kind.#{k}"),k]}, {prompt: '選択してください'} %>
   </div>
-  <div class="forn-group">
+  <div class="form-group">
+    <%= f.hidden_field :site_id, value: @site.id %>
+  </div>
+  <div class="form-group">
     <%= f.submit '次へ' %>
   </div>
 <% end %>

--- a/app/views/site_memos/new_step1.html.erb
+++ b/app/views/site_memos/new_step1.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: site_memos_form_switcher_path, method: :get, local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :kind, '施工内容' %>
+    <%= f.select :kind, ConstructionMaterial.kinds.keys.map{ |k| [I18n.t("enums.construction_material.kind.#{k}"),k]}, {prompt: '選択してください'} %>
+  </div>
+  <div class="forn-group">
+    <%= f.submit '次へ' %>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module SashMemo
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.i18n.default_locale = :ja  #デフォルト言語を日本語に設定
+    config.i18n.fallbacks =[:en]
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,8 @@
 ja:
+  enums:
+    construction_material:
+      kind:
+        inner_sash: '内窓'
   activerecord:
     errors:
       messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   get 'site_memos/index/:site_id', to: 'site_memos#index', as: :site_memos_index
+  get 'site_memos/new_step1/:site_id', to: 'site_memos#new_step1', as: :site_memos_new_step1
+  get 'site_memos/form_switcher'
   root 'homes#top'
   get 'sign_in/index'
   get 'sign_up/index'


### PR DESCRIPTION
## 目的
現場メモ作成機能のstep1を追加。施工内容を送信するためのフォームになっている。

## 変更点
- site_memos_controller
   - new_step1
   - form_switcher

- construction_material.rb
   - enumの設定

- site_memos/index.html.erb
   - メモ追加画面に遷移するリンク追加

- new_step1.html.erb
   - 施工内容を送信するフォーム

- routes.rb
   - 各種ルーティング設定