### PR TITLE
現場メモ作成機能（施工内容入力ページ）変更

### DIFF
--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -5,7 +5,7 @@ class SiteMemosController < ApplicationController
   end
 
   def new_step1(site_id:)
-    @site = Site.find(site_id)
+    session[:site_id] = site_id #セッションに保存させるようにする
   end
 
   def form_switcher(kind:)

--- a/app/views/site_memos/new_step1.html.erb
+++ b/app/views/site_memos/new_step1.html.erb
@@ -4,9 +4,6 @@
     <%= f.select :kind, ConstructionMaterial.kinds.keys.map{ |k| [I18n.t("enums.construction_material.kind.#{k}"),k]}, {prompt: '選択してください'} %>
   </div>
   <div class="form-group">
-    <%= f.hidden_field :site_id, value: @site.id %>
-  </div>
-  <div class="form-group">
     <%= f.submit '次へ' %>
   </div>
 <% end %>


### PR DESCRIPTION
## 目的
site_idをhidden_fieldを用いてパラメーターで送信していたが、セッションに入れた方がform_switcherの後のコントローラーでも容易に使うことができるため、site_idをセッションに保存するようにした

## 変更点
- site_memos_controller.rb
  - new_step1
  
- site_memos/new_step1.html.erb