### PR TITLE
現場作成機能更新

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -26,7 +26,8 @@ class SitesController < ApplicationController
 
   def create(site)
     Site.create_with_contractor_or_find(site: site.merge(user_id: current_user.id))
-    return redirect_to sites_index_path, notice: '現場を作成しました'
-    return redirect_to sites_new_path, alert: @site.errors.full_messages
+    redirect_to sites_index_path, notice: '現場を作成しました'
+  rescue => e
+    redirect_to sites_new_path, alert: e
   end
 end

--- a/app/models/contractor.rb
+++ b/app/models/contractor.rb
@@ -5,9 +5,14 @@ class Contractor < ApplicationRecord
   has_many :sites
 
   validates :name, presence: true, length: {maximum: 30}
+
+  # scope :find_by_name_and_user, -> (name:, user_id:){ where(name: name, user_id: user_id ).limit(1)}
+
+  def self.find_by_name_and_user(name:, user_id:)
+    self.find_by(name: name, user_id: user_id)
+  end
   
   scope :suggest_name, -> (name:){ suggest_hira_name(name: name).or(suggest_kana_name(name: name)) }
-
   scope :suggest_hira_name, -> (name:){ where('name LIKE ? ', "%#{sanitize_sql_like(name.to_s.to_hira)}%") }
   scope :suggest_kana_name, -> (name:){ where('name LIKE ? ', "%#{sanitize_sql_like(name.to_s.to_kana)}%") }
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,7 +2,26 @@ class Site < ApplicationRecord
   belongs_to :user
   belongs_to :contractor
   has_many :site_memos, dependent: :destroy
+  accepts_nested_attributes_for :contractor
 
  validates :name, presence: true, length: {maximum: 30}
  validates :address, presence: true, length: {maximum: 50}
+
+ #viewで入力されたcontractorがあるかないかを調べてデータの作り方決める
+ def self.create_with_contractor_or_find(site:)
+  user_id = site[:user_id]
+  contractor_name = site[:contractor_attributes][:name]
+  contractor = Contractor.find_by_name_and_user(name: contractor_name, user_id: user_id)
+
+  if contractor
+    # siteのみ作りたい処理
+    site.delete(:contractor_attributes)
+    site[:contractor_id] = contractor.id
+  else
+    # contractorも一緒に作りたいので、contractorにuserを紐づける
+    site[:contractor_attributes][:user_id] = user_id
+  end
+
+  self.create!(site)
+ end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,24 +4,33 @@ class Site < ApplicationRecord
   has_many :site_memos, dependent: :destroy
   accepts_nested_attributes_for :contractor
 
- validates :name, presence: true, length: {maximum: 30}
- validates :address, presence: true, length: {maximum: 50}
+  validates :name, presence: true, length: {maximum: 30}
+  validates :address, presence: true, length: {maximum: 50}
+  validate :date_before_today
 
  #viewで入力されたcontractorがあるかないかを調べてデータの作り方決める
- def self.create_with_contractor_or_find(site:)
-  user_id = site[:user_id]
-  contractor_name = site[:contractor_attributes][:name]
-  contractor = Contractor.find_by_name_and_user(name: contractor_name, user_id: user_id)
+  def self.create_with_contractor_or_find(site:)
+    user_id = site[:user_id]
+    contractor_name = site[:contractor_attributes][:name]
+    contractor = Contractor.find_by_name_and_user(name: contractor_name, user_id: user_id)
 
-  if contractor
-    # siteのみ作りたい処理
-    site.delete(:contractor_attributes)
-    site[:contractor_id] = contractor.id
-  else
-    # contractorも一緒に作りたいので、contractorにuserを紐づける
-    site[:contractor_attributes][:user_id] = user_id
+    if contractor
+      # siteのみ作りたい処理
+      site.delete(:contractor_attributes)
+      site[:contractor_id] = contractor.id
+    else
+      # contractorも一緒に作りたいので、contractorにuserを紐づける
+      site[:contractor_attributes][:user_id] = user_id
+    end
+
+    self.create!(site)
   end
 
-  self.create!(site)
- end
+  private
+
+  def date_before_today
+    message = "は今日以降を指定してください"
+    errors.add(:construction_date, message) if construction_date && construction_date < Date.today
+    errors.add(:research_date, message) if research_date && research_date < Date.today
+  end
 end

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -2,14 +2,15 @@
 <!--開発都合で設置したリンク-->
 <%= link_to 'ホームに戻る', sites_index_path %>
 
-<%= form_with url: sites_create_path, local: true do |f| %>
-  <div class="form-group">
-    <%= f.label :contractor_name, '元請'%>
-    <%= f.text_field :contractor_name, required: true%><br />
-    <!-- リストにする-->
-    <ul id="search-result">
-    </ul>
-  </div>
+<%= form_with model: @site,  url: sites_create_path, method: :post, local: true do |f| %>
+  <%= f.fields_for :contractor do |contractor| %>
+    <div class="form-group">
+      <%= contractor.label :name, '元請'%>
+      <%= contractor.text_field :name, id: 'contractor_name', required: true%><br />
+    </div>
+  <% end %>
+  <ul id="search-result">
+  </ul>
   <div class="form-group">
     <%= f.label :name, '現場名' %>
     <%= f.text_field :name, required: true %>
@@ -20,8 +21,8 @@
     <%= f.text_field :address, required: true%>
   </div>
   <div class="form-group">
-    <%= f.check_box :setting_research %>
-    <%= f.label :setting_research, '現調日時を設定する' %>
+    <p>チェックボックスにして、チェックついたらフォーム出す</p>
+    <p>現場日時を設定する</p>
   </div>
   <div class="form-group">
     <%= f.label :research_date, '現調日' %>
@@ -32,8 +33,8 @@
     <%= f.time_field :research_start_time %>
   </div>
   <div class="form-group">
-    <%= f.check_box :setting_research %>
-    <%= f.label :setting_research, '工事日時を設定する' %>
+    <p>チェックボックスにして、チェックついたらフォーム出す</p>
+    <p>工事日時を設定する</p>
   </div>
   <div class="form-group">
     <%= f.label :construction_date, '工事日' %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -41,6 +41,10 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    attributes:
+      site:
+        research_date: '現調日'
+        construction_date: '工事日'
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
## 概要
既存の現場作成機能の処理をリファクタリングをし、新たにバリデーションを追加した

## やったこと
- siteデータの作成処理
- 既存のcontractorデータを使うか、新規作成するかの処理
  - ユーザーに紐づいているcontractorを指定した場合はcontractorを作らない（siteのみ作る）
  - contractorがない場合は、新規作成
- siteモデルの日付関係のバリデーション

## やってないこと
- その他のバリデーション
- チェックボックスで動的にフォームを表示させる

## 課題・疑問点
