### PR TITLE
現場メモ作成機能（内容選択）修正

### DIFF
--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -5,7 +5,7 @@ class InnerSashesController < ApplicationController
           :glass_color, :glass_thickness, :glass_kind, :is_low_e, :action, site_memo_attributes: [:id, :site_id, :room, :remark],
           photos_attributes: [:id, :file_name, :_destroy]
 
-  def new_step2(site_id:)
+  def new_step2
     #下書きがあれば下書きからデータを取ってくる処理を追加
     @site_id = site_id
     @inner_sash = InnerSash.new

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -23,20 +23,13 @@ class SiteMemosController < ApplicationController
     @site_memo = SiteMemo.new
   end
 
-  def find_or_create(site_memo)
-    # 既存を探す
+  def form_switcher(site_memo)
     site_id = session[:site_id]
     kind = site_memo[:kind]
-    session.delete(:site_id) #次のページ以降使うなら消す
-
     exist_sm = SiteMemo.eager_load(:site).find_by(site_id: site_id, kind: kind)
-    redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_#{exist_sm.status}/#{site_id}" and return if exist_sm && exist_sm.status !='published'
-    redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_step2/#{site_id}" and return if exist_sm
 
-    # 新規作成
-    s_memo = SiteMemo.new(site_memo.merge(site_id: site_id))
-    redirect_to "/#{s_memo.kind.to_s.pluralize}/new_step2/site_memo.site_id" and return if s_memo.save
-    redirect_to site_memos_new_step1_path(site_id), alert: s_memo.errors.full_messages
+    return redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_#{exist_sm.status}" if exist_sm && exist_sm.status !='published'
+    return redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_step2"
   end
 
   def show_switcher(kind:, id:)

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -24,8 +24,11 @@ class SiteMemosController < ApplicationController
   end
 
   def form_switcher(site_memo)
-    site_id = session[:site_id]
     kind = site_memo[:kind]
+    site_id = session[:site_id]
+
+    return redirect_to site_memos_new_step1_path(site_id), alert: "施工内容を選択してください" if kind.blank?
+
     exist_sm = SiteMemo.eager_load(:site).find_by(site_id: site_id, kind: kind)
 
     return redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_#{exist_sm.status}" if exist_sm && exist_sm.status !='published'

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -1,5 +1,5 @@
 class SiteMemosController < ApplicationController
-  permits :id, :kind, :site_id
+  permits :kind
 
   def index(site_id:)
     @site = Site.find(site_id)

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -31,6 +31,7 @@ class SiteMemosController < ApplicationController
 
     exist_sm = SiteMemo.eager_load(:site).find_by(site_id: site_id, kind: kind)
 
+    return redirect_to "/#{kind.pluralize}/new_step2" if exist_sm.blank?
     return redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_#{exist_sm.status}" if exist_sm && exist_sm.status !='published'
     return redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_step2"
   end

--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -1,4 +1,6 @@
 class SiteMemosController < ApplicationController
+  permits :id, :kind, :site_id
+
   def index(site_id:)
     @site = Site.find(site_id)
     #site_memoの全ての子モデル結合して取得
@@ -17,20 +19,29 @@ class SiteMemosController < ApplicationController
   end
 
   def new_step1(site_id:)
-    @site_id = site_id
+    session[:site_id] = site_id
+    @site_memo = SiteMemo.new
+  end
+
+  def find_or_create(site_memo)
+    # 既存を探す
+    site_id = session[:site_id]
+    kind = site_memo[:kind]
+    session.delete(:site_id) #次のページ以降使うなら消す
+
+    exist_sm = SiteMemo.eager_load(:site).find_by(site_id: site_id, kind: kind)
+    redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_#{exist_sm.status}/#{site_id}" and return if exist_sm && exist_sm.status !='published'
+    redirect_to "/#{exist_sm.kind.to_s.pluralize}/new_step2/#{site_id}" and return if exist_sm
+
+    # 新規作成
+    s_memo = SiteMemo.new(site_memo.merge(site_id: site_id))
+    redirect_to "/#{s_memo.kind.to_s.pluralize}/new_step2/site_memo.site_id" and return if s_memo.save
+    redirect_to site_memos_new_step1_path(site_id), alert: s_memo.errors.full_messages
   end
 
   def show_switcher(kind:, id:)
     redirect_to inner_sashes_show_path(id) if kind == 'inner_sash' 
     #他のモデルが追加されたら分岐を追加
-  end
-
-  def form_switcher(kind:, site_id:)
-    # site_memoのstatusの条件でどこのページに飛ばすかを追加する予定
-    case kind
-    when 'inner_sash'
-      redirect_to inner_sashes_new_step2_path(site_id)
-    end
   end
 
   def destroy(id:)

--- a/app/models/site_memo.rb
+++ b/app/models/site_memo.rb
@@ -1,6 +1,6 @@
 class SiteMemo < ApplicationRecord
   enum kind: { inner_sash: 0 } 
-  enum status: { step1: 0, step2: 1, step3: 2, step4: 3, published: 4  }
+  enum status: { step2: 0, step3: 1, step4: 2, step5: 3, published: 4 }
   enum order: { unordered: 0 , ordered: 1 }
 
   belongs_to :site

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,7 +1,0 @@
-  <% if model.errors.any?  %>
-    <ul>
-      <% model.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  <% end %>

--- a/app/views/site_memos/new_step1.html.erb
+++ b/app/views/site_memos/new_step1.html.erb
@@ -1,9 +1,8 @@
-<%= form_with url: site_memos_form_switcher_path, method: :get, local: true do |f| %>
+<%= form_with model: @site_memo, url: site_memos_find_or_create_path, local: true do |f| %>
   <div class="form-group">
     <%= f.label :kind, '施工内容' %>
-    <%= f.select :kind, SiteMemo.kinds.keys.map{ |k| [I18n.t("enums.site_memo.kind.#{k}"),k]}, {prompt: '選択してください'}, required: true %>
+    <%= f.select :kind, SiteMemo.kinds.keys.map{ |k| [I18n.t("enums.site_memo.kind.#{k}"),k]}, {prompt: '選択してください'} %>
   </div>
-  <%= f.hidden_field :site_id, value: @site_id %>
   <div class="form-group">
     <%= f.submit '次へ' %>
   </div>

--- a/app/views/site_memos/new_step1.html.erb
+++ b/app/views/site_memos/new_step1.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @site_memo, url: site_memos_find_or_create_path, local: true do |f| %>
+<%= form_with model: @site_memo, url: site_memos_form_switcher_path, local: true do |f| %>
   <div class="form-group">
     <%= f.label :kind, '施工内容' %>
     <%= f.select :kind, SiteMemo.kinds.keys.map{ |k| [I18n.t("enums.site_memo.kind.#{k}"),k]}, {prompt: '選択してください'} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   post 'site_memos/update_bulk_order/:site_id', to: 'site_memos#update_bulk_order', as: :site_memos_update_bulk_order
   get 'site_memos/show_switcher/:kind/:id', to: 'site_memos#show_switcher', as: :site_memos_show_switcher
   get 'site_memos/new_step1/:site_id', to: 'site_memos#new_step1', as: :site_memos_new_step1
-  get 'site_memos/form_switcher'
+  post 'site_memos/find_or_create'
   delete 'site_memos/destroy/:id', to: 'site_memos#destroy', as: :site_memos_destroy
   get 'inner_sashes/new_step2/:site_id', to: 'inner_sashes#new_step2', as: :inner_sashes_new_step2
   get 'inner_sashes/new_step3/:site_id', to: 'inner_sashes#new_step3', as: :inner_sashes_new_step3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,9 @@ Rails.application.routes.draw do
   post 'site_memos/update_bulk_order/:site_id', to: 'site_memos#update_bulk_order', as: :site_memos_update_bulk_order
   get 'site_memos/show_switcher/:kind/:id', to: 'site_memos#show_switcher', as: :site_memos_show_switcher
   get 'site_memos/new_step1/:site_id', to: 'site_memos#new_step1', as: :site_memos_new_step1
-  post 'site_memos/find_or_create'
+  post 'site_memos/form_switcher'
   delete 'site_memos/destroy/:id', to: 'site_memos#destroy', as: :site_memos_destroy
-  get 'inner_sashes/new_step2/:site_id', to: 'inner_sashes#new_step2', as: :inner_sashes_new_step2
+  get 'inner_sashes/new_step2'
   get 'inner_sashes/new_step3/:site_id', to: 'inner_sashes#new_step3', as: :inner_sashes_new_step3
   get 'inner_sashes/new_step4/:site_memo_id', to: 'inner_sashes#new_step4', as: :inner_sashes_new_step4
   get 'inner_sashes/new_step5/:site_memo_id', to: 'inner_sashes#new_step5', as: :inner_sashes_new_step5


### PR DESCRIPTION
## 概要
現場メモ作成フォーム（ウィザードフォーム）の一番最初の内容選択するフォームを送信した時の処理を修正。
リファクタリングや、データの状況によりリダイレクト先を分岐させるようにした。

## やったこと
- 内容選択送信後の分岐
- sessionに一部データを保存
- ルーティングパスの変更
- リダイレクト先の指定にenum等を使用して簡素化
- enum変更
- era-

## やってないこと
- リダイレクト先が分岐する全パターンのテスト

## 課題・疑問点

その他場合によって```UI before/after``` ```注意事項``` ```備考``` ```どうやるのか```など追加
