### PR TITLE
現場メモ新規作成（施工内容入力）修正

### DIFF
--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -25,11 +25,15 @@ class SiteMemosController < ApplicationController
   def form_switcher(site_memo)
     kind = site_memo[:kind]
     site_id = session[:site_id]
-    
-    return redirect_to site_memos_new_step1_path(site_id), alert: "施工内容を選択してください" if kind.blank?
 
+    @site_memo = SiteMemo.new(site_id: site_id, kind: kind)
     exist_sm = SiteMemo.eager_load(:site).find_by(site_id: site_id, kind: kind)
-    return redirect_to "/#{kind.pluralize}/new_step2" if exist_sm.blank?
+
+    if exist_sm.blank? && @site_memo.save
+      return redirect_to "/#{kind.pluralize}/new_step2"
+    elsif exist_sm.blank?
+      return render 'new_step1', status: :unprocessable_entity
+    end
     
     kind = exist_sm.kind.to_s.pluralize
     status = exist_sm.status

--- a/app/views/site_memos/new_step1.html.erb
+++ b/app/views/site_memos/new_step1.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: @site_memo, url: site_memos_form_switcher_path, local: true do |f| %>
+  <%= render 'layouts/alert', obj: f.object %>
   <div class="form-group">
     <%= f.label :kind, '施工内容' %>
     <%= f.select :kind, SiteMemo.kinds.keys.map{ |k| [I18n.t("enums.site_memo.kind.#{k}"),k]}, {prompt: '選択してください'} %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -74,7 +74,7 @@ ja:
       contractor:
         name: '名前'
       site_memo:
-        kind: '内容'
+        kind: '施工内容'
         room: '部屋名'
         order: '発注状況'
         remark: '備考'


### PR DESCRIPTION
## 概要
site_memoとinner_sashの関係を１対１から１対多に変更したので、site_memoのデータをnew_step1であらかじめ作成することにした。その方がnew_step2以降の処理が楽なので。

## やったこと
- site_memoの新規作成処理
- 遷移先の分岐を変更
- エラーメッセージの表示
- エラー項目の変更

## やってないこと

## 課題・疑問点

