### PR TITLE
現場メモ新規作成（内窓寸法入力）修正

### DIFF
--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -7,17 +7,15 @@ class InnerSashesController < ApplicationController
 
   def new_step2
     site_id = session[:site_id]
-    @inner_sash_datas = load_inner_sashes(site_id: site_id)
-    @site_memo = SiteMemo.new
-    @inner_sashes = @site_memo.inner_sashes.build
+    @inner_sashes = load_inner_sashes(site_id: site_id)
+    @inner_sash = InnerSash.new
   end
 
-  def new_append_room(site_memo)
+  def new_append_room
     site_id = session[:site_id]
-    @site_memo = SiteMemo.create_and_find_site_memo(site_memo: site_memo, site_id: site_id)
-    @inner_sash_datas = load_inner_sashes(site_id: site_id)
-    @site_memo = SiteMemo.new if @site_memo.errors.full_messages.blank?
-    @inner_sashes = @site_memo.inner_sashes.build(site_memo)
+    @inner_sash = InnerSash.new(inner_sash_params)
+    @inner_sash = InnerSash.new if @inner_sash.save
+    @inner_sashes = load_inner_sashes(site_id: site_id)
   end
 
   def new_step3
@@ -133,17 +131,16 @@ class InnerSashesController < ApplicationController
 private
 
   def inner_sash_params
-    permits.require(:inner_sash).permit(:room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
-      :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth)
+    params.require(:inner_sash).permit(:room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
+                                      :height_left_size, :height_middle_size, :height_right_size, 
+                                      :width_frame_depth, :height_frame_depth).merge(site_memo_id: load_site_memo.id)
   end
-
-  def
 
   def load_inner_sashes(site_id:)
     InnerSash.eager_load(:site_memo).where(site_memo: {site_id: site_id})
   end
 
-  def load_site_memo(site_id:)
-    @site_memo = SiteMemo.find_by(site_id: site_id)
+  def load_site_memo
+    @site_memo = SiteMemo.find_by(site_id: session[:site_id], kind: 'inner_sash')
   end
 end

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -1,24 +1,23 @@
 class InnerSashesController < ApplicationController
   permits inner_sashes_attributes: [:id, :room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
-          :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,
-          :color, :is_flat_bar, :hanging_origin, :key_height, :sash_type, :middle_frame_height, :is_adjust,
-          :glass_color, :glass_thickness, :glass_kind, :is_low_e, :action],
-          photos_attributes: [:id, :file_name, :_destroy], model_name: 'SiteMemo'
+    :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,
+    :color, :is_flat_bar, :hanging_origin, :key_height, :sash_type, :middle_frame_height, :is_adjust,
+    :glass_color, :glass_thickness, :glass_kind, :is_low_e, :action],
+    photos_attributes: [:id, :file_name, :_destroy], model_name: 'SiteMemo'
 
   def new_step2
-    #下書きがあれば下書きからデータを取ってくる処理を追加
-    @inner_sash = InnerSash.new
     site_id = session[:site_id]
-    load_inner_sashes(site_id: site_id)
+    @inner_sash_datas = load_inner_sashes(site_id: site_id)
+    @site_memo = SiteMemo.new
+    @inner_sashes = @site_memo.inner_sashes.build
   end
 
-  def new_append_room(inner_sash)
+  def new_append_room(site_memo)
     site_id = session[:site_id]
-    new_inner = InnerSash.create_and_find_site_memo(inner_sash: inner_sash, site_id: site_id)
-
-    load_inner_sashes(site_id: site_id)
-    return @inner_sash = InnerSash.new if new_inner.errors.full_messages.blank?
-    @inner_sash = new_inner
+    @site_memo = SiteMemo.create_and_find_site_memo(site_memo: site_memo, site_id: site_id)
+    @inner_sash_datas = load_inner_sashes(site_id: site_id)
+    @site_memo = SiteMemo.new if @site_memo.errors.full_messages.blank?
+    @inner_sashes = @site_memo.inner_sashes.build(site_memo)
   end
 
   def new_step3
@@ -133,8 +132,15 @@ class InnerSashesController < ApplicationController
 
 private
 
+  def inner_sash_params
+    permits.require(:inner_sash).permit(:room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
+      :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth)
+  end
+
+  def
+
   def load_inner_sashes(site_id:)
-    @inner_sashes = InnerSash.eager_load(:site_memo).where(site_memo: {site_id: site_id})
+    InnerSash.eager_load(:site_memo).where(site_memo: {site_id: site_id})
   end
 
   def load_site_memo(site_id:)

--- a/app/models/inner_sash.rb
+++ b/app/models/inner_sash.rb
@@ -34,13 +34,6 @@ class InnerSash < ApplicationRecord
   validates :glass_thickness, presence: true
   validates :is_low_e, inclusion: {in: [true, false]}
 
-  def self.create_and_find_site_memo(inner_sash:, site_id:)
-    inner_sash
-    site_memo = SiteMemo.find_by(site_id: site_id, kind: 'inner_sash')
-    inner_sash = site_memo.inner_sashes.create(inner_sash)
-    return inner_sash
-  end
-
   def previous
     InnerSash.eager_load(site_memo: :site).where(site: {id: self.site_memo.site_id}).where("inner_sashes.id<?", self.id).order(id: :desc).first
   end

--- a/app/models/site_memo.rb
+++ b/app/models/site_memo.rb
@@ -11,4 +11,10 @@ class SiteMemo < ApplicationRecord
   validates :status, presence: true
   validates :remark, length: { maximum:100 }
 
+  def self.create_and_find_site_memo(site_memo:, site_id:)
+    @site_memo = self.find_by(site_id: site_id, kind: 'inner_sash')
+    @site_memo.update(site_memo)
+    return @site_memo
+  end
+
 end

--- a/app/models/site_memo.rb
+++ b/app/models/site_memo.rb
@@ -11,10 +11,4 @@ class SiteMemo < ApplicationRecord
   validates :status, presence: true
   validates :remark, length: { maximum:100 }
 
-  def self.create_and_find_site_memo(site_memo:, site_id:)
-    @site_memo = self.find_by(site_id: site_id, kind: 'inner_sash')
-    @site_memo.update(site_memo)
-    return @site_memo
-  end
-
 end

--- a/app/views/inner_sashes/new_append_room.turbo_stream.erb
+++ b/app/views/inner_sashes/new_append_room.turbo_stream.erb
@@ -1,17 +1,19 @@
 <%= turbo_stream.update 'room-list' do %>
-  <% @inner_sashes.each do |inner_sash| %>
+  <% @inner_sash_datas.each do |inner_sash| %>
     <%= inner_sash.room %>
   <% end %>
 <% end %>
 
 <%= turbo_stream.update 'inner-sash-size-form' do %>
-  <%= form_with model: @inner_sash, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
+  <%= form_with model: @site_memo, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
     <%= render 'layouts/alert', obj: f.object %>
-    <div class="form-group">
-      <%= f.label :room, '部屋' %>
-      <%= f.text_field :room %>
-    </div>
-    <%= render partial: 'form_size', locals: { inner_sash: f } %>
+    <%= f.fields_for :inner_sashes do|inner_sash| %>
+      <div class="form-group">
+        <%= inner_sash.label :room, '部屋' %>
+        <%= inner_sash.text_field :room, required: true%>
+      </div>
+      <%= render 'form_size', inner_sash: inner_sash %>
+    <% end %>
     <%= f.submit '追加' %>
   <% end %>
 <% end %>

--- a/app/views/inner_sashes/new_append_room.turbo_stream.erb
+++ b/app/views/inner_sashes/new_append_room.turbo_stream.erb
@@ -1,19 +1,17 @@
 <%= turbo_stream.update 'room-list' do %>
-  <% @inner_sash_datas.each do |inner_sash| %>
+  <% @inner_sashes.each do |inner_sash| %>
     <%= inner_sash.room %>
   <% end %>
 <% end %>
 
 <%= turbo_stream.update 'inner-sash-size-form' do %>
-  <%= form_with model: @site_memo, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
+  <%= form_with model: @inner_sash, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
     <%= render 'layouts/alert', obj: f.object %>
-    <%= f.fields_for :inner_sashes do|inner_sash| %>
-      <div class="form-group">
-        <%= inner_sash.label :room, '部屋' %>
-        <%= inner_sash.text_field :room, required: true%>
-      </div>
-      <%= render 'form_size', inner_sash: inner_sash %>
-    <% end %>
+    <div class="form-group">
+      <%= f.label :room, '部屋' %>
+      <%= f.text_field :room, required: true%>
+    </div>
+    <%= render 'form_size', inner_sash: f %>
     <%= f.submit '追加' %>
   <% end %>
 <% end %>

--- a/app/views/inner_sashes/new_step2.html.erb
+++ b/app/views/inner_sashes/new_step2.html.erb
@@ -1,15 +1,18 @@
 <div id="room-list">
-  <% @inner_sashes.each do |inner_sash| %>
+  <% @inner_sash_datas.each do |inner_sash| %>
     <%= inner_sash.room %>
   <% end %>
 </div>
+
 <%= turbo_frame_tag 'inner-sash-size-form' do %>
-  <%= form_with model: @inner_sash, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
-    <div class="form-group">
-      <%= f.label :room, '部屋' %>
-      <%= f.text_field :room, required: true%>
-    </div>
-    <%= render partial: 'form_size', locals: { inner_sash: f } %>
+  <%= form_with model: @site_memo, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
+    <%= f.fields_for :inner_sashes do |inner_sash| %>
+      <div class="form-group">
+        <%= inner_sash.label :room, '部屋' %>
+        <%= inner_sash.text_field :room, required: true%>
+      </div>
+      <%= render 'form_size', inner_sash: inner_sash %>
+    <% end %>
     <%= f.submit '追加' %>
   <% end %>
 <% end %>

--- a/app/views/inner_sashes/new_step2.html.erb
+++ b/app/views/inner_sashes/new_step2.html.erb
@@ -1,18 +1,16 @@
 <div id="room-list">
-  <% @inner_sash_datas.each do |inner_sash| %>
+  <% @inner_sashes.each do |inner_sash| %>
     <%= inner_sash.room %>
   <% end %>
 </div>
 
 <%= turbo_frame_tag 'inner-sash-size-form' do %>
-  <%= form_with model: @site_memo, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
-    <%= f.fields_for :inner_sashes do |inner_sash| %>
-      <div class="form-group">
-        <%= inner_sash.label :room, '部屋' %>
-        <%= inner_sash.text_field :room, required: true%>
-      </div>
-      <%= render 'form_size', inner_sash: inner_sash %>
-    <% end %>
+  <%= form_with model: @inner_sash, url: inner_sashes_new_append_room_path, data: { turbo_stream: true } do |f|%>
+    <div class="form-group">
+      <%= f.label :room, '部屋' %>
+      <%= f.text_field :room, required: true%>
+    </div>
+    <%= render 'form_size', inner_sash: f %>
     <%= f.submit '追加' %>
   <% end %>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -49,7 +49,7 @@ ja:
         research_start_time: '現調開始時間'
         construction_date: '工事日'
         construction_start_time: '工事開始時間'
-      inner_sashes:
+      inner_sash:
         color: '色'
         number_of_shoji: '障子枚数'
         width_up_size: '横：上部寸法'


### PR DESCRIPTION
## 概要
内窓新規作成の寸法情報入力ページで、パラメーターをaction argsを用いて新規作成を行なっていたが、通常のストロングパラメーターを使うことにした。理由はaction argsを使うとコードが複雑になり、エラーが起きるため。

## やったこと
- 通常のストロングパラメータの作成
- 変更に伴ったリファクタリング

## やってないこと

## 課題・疑問点
- action argsと通常のストロングパラメーターが両方存在しているのだが、一つに絞るべきか？

