### PR TITLE
現場メモ新規作成（内窓基本情報）機能修正

### DIFF
--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -6,27 +6,23 @@ class InnerSashesController < ApplicationController
     photos_attributes: [:id, :file_name, :_destroy], model_name: 'SiteMemo'
 
   def new_step2
-    site_id = session[:site_id]
-    @inner_sashes = load_inner_sashes(site_id: site_id)
+    load_inner_sashes
     @inner_sash = InnerSash.new
   end
 
   def new_append_room
-    site_id = session[:site_id]
     @inner_sash = InnerSash.new(inner_sash_params)
     @inner_sash = InnerSash.new if @inner_sash.save
-    @inner_sashes = load_inner_sashes(site_id: site_id)
+    load_inner_sashes
   end
 
   def new_step3
-    site_id = session[:site_id]
-    load_site_memo(site_id: site_id)
-    @inner_sashes = @site_memo.inner_sashes
+    load_site_memo
+    load_inner_sashes
   end
 
   def new_append_basic_info(site_memo)
-    site_id = session[:site_id]
-    load_site_memo(site_id: site_id)
+    load_site_memo
     return redirect_to inner_sashes_new_step4_path if @site_memo.update(site_memo)
     return render "new_step3", status: :unprocessable_entity
   end
@@ -136,11 +132,11 @@ private
                                       :width_frame_depth, :height_frame_depth).merge(site_memo_id: load_site_memo.id)
   end
 
-  def load_inner_sashes(site_id:)
-    InnerSash.eager_load(:site_memo).where(site_memo: {site_id: site_id})
+  def load_inner_sashes
+    @inner_sashes = InnerSash.eager_load(:site_memo).where(site_memo: {site_id: session[:site_id]})
   end
 
   def load_site_memo
-    @site_memo = SiteMemo.find_by(site_id: session[:site_id], kind: 'inner_sash')
+    @site_memo = SiteMemo.find_by(kind: 'inner_sash', site_id: session[:site_id])
   end
 end

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -24,6 +24,7 @@ class InnerSashesController < ApplicationController
   def new_append_basic_info(site_memo)
     load_site_memo
     return redirect_to inner_sashes_new_step4_path if @site_memo.update(site_memo)
+    load_inner_sashes
     return render "new_step3", status: :unprocessable_entity
   end
 

--- a/app/views/inner_sashes/_inner_sash.html.erb
+++ b/app/views/inner_sashes/_inner_sash.html.erb
@@ -1,0 +1,1 @@
+<%= inner_sash.room %>

--- a/app/views/inner_sashes/new_append_room.turbo_stream.erb
+++ b/app/views/inner_sashes/new_append_room.turbo_stream.erb
@@ -1,7 +1,5 @@
 <%= turbo_stream.update 'room-list' do %>
-  <% @inner_sashes.each do |inner_sash| %>
-    <%= inner_sash.room %>
-  <% end %>
+  <%= render @inner_sashes %>
 <% end %>
 
 <%= turbo_stream.update 'inner-sash-size-form' do %>

--- a/app/views/inner_sashes/new_step2.html.erb
+++ b/app/views/inner_sashes/new_step2.html.erb
@@ -1,7 +1,5 @@
 <div id="room-list">
-  <% @inner_sashes.each do |inner_sash| %>
-    <%= inner_sash.room %>
-  <% end %>
+  <%= render @inner_sashes %>
 </div>
 
 <%= turbo_frame_tag 'inner-sash-size-form' do %>

--- a/app/views/inner_sashes/new_step3.html.erb
+++ b/app/views/inner_sashes/new_step3.html.erb
@@ -1,4 +1,6 @@
 <p>new_step3</p>
+<%= render @inner_sashes %>
+
 <%= form_with model: @site_memo, url: inner_sashes_new_append_basic_info_path, local: true do |f| %>
   <%= render 'layouts/alert', obj: f.object %>
   <%= f.fields_for :inner_sashes do |inner_sash| %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -77,6 +77,28 @@ ja:
         kind: '施工内容'
         order: '発注状況'
         remark: '備考' 
+      inner_sashes:
+        color: '色'
+        number_of_shoji: '障子枚数'
+        width_up_size: '横：上部寸法'
+        width_down_size: '横：下部寸法'
+        width_middle_size: '横：中央寸法'
+        height_right_size: '縦：右寸法'
+        height_left_size: '縦：左寸法'
+        height_middle_size: '縦：中央寸法'
+        width_frame_depth: '横：窓枠奥行き寸法'
+        height_frame_depth: '縦：窓枠奥行き寸法'
+        is_flat_bar: '平板'
+        key_height: 'クレセントH寸法'
+        sash_type: 'サッシ種類'
+        middle_frame_height: '中桟H寸法'
+        is_adjust: 'アジャスト上枠'
+        hanging_origin: '吊り元'
+        glass_color: 'ガラス色'
+        glass_thickness: 'ガラス厚み'
+        glass_kind: 'ガラス種類'
+        is_low_e: 'Low-E'
+        room: '部屋名'
 
   date:
     abbr_day_names:


### PR DESCRIPTION
## 概要
現場メモ新規作成の内窓基本情報入力ページで部屋名のリストを表示するようにし、それを使い回すので部分テンプレート化。他のページも部分テンプレに対応させ、その他リファクタリング

## やったこと
- 部屋名のリストを表示
- 部分テンプレート化
- リファクタリング
- エラーメッセージの日本語化

## やってないこと
- 部屋名の横に削除ボタン

## 課題・疑問点

