### PR TITLE
内窓障子・ガラス編集機能修正

### DIFF
--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -126,7 +126,9 @@ private
   def inner_sash_params
     params.require(:inner_sash).permit(:room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, 
-                                      :width_frame_depth, :height_frame_depth, :is_flat_bar, :is_adjust, :action, photos_attributes: [:id, :file_name, :_destroy]).merge(site_memo_id: load_site_memo.id)
+                                      :width_frame_depth, :height_frame_depth, :is_flat_bar, :is_adjust, 
+                                      :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height,
+                                      :action, photos_attributes: [:id, :file_name, :_destroy]).merge(site_memo_id: load_site_memo.id)
   end
 
   def load_inner_sashes

--- a/app/views/inner_sashes/_shoji_and_glass_fields.html.erb
+++ b/app/views/inner_sashes/_shoji_and_glass_fields.html.erb
@@ -3,7 +3,7 @@
   <%= inner_sash.select :glass_thickness, InnerSash.glass_thicknesses.keys.map{ |k| [I18n.t("enums.inner_sash.glass_thickness.#{k}"),k] } %>
 </div>
 <div class="form-group">
-  <%= inner_sash.label :glass_thickness, '種類' %>
+  <%= inner_sash.label :glass_kind, '種類' %>
   <%= inner_sash.select :glass_kind, InnerSash.glass_kinds.keys.map{ |k| [I18n.t("enums.inner_sash.glass_kind.#{k}"),k] } %>
 </div>
 <div class="form-group">

--- a/app/views/inner_sashes/edit_shoji_and_glass.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_shoji_and_glass.turbo_stream.erb
@@ -1,8 +1,7 @@
 <%= turbo_stream.replace 'shoji-and-glass' do %>
   <%= turbo_frame_tag 'shoji-and-glass' do %>
-    <%= form_with model: @inner_sash, url: inner_sashes_update_path do |f| %>
-      <%= render partial: 'form_shoji_and_glass', locals: { inner_sash:  f } %>
-      <%= f.hidden_field :id, value: @inner_sash.id %>
+    <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id) do |f| %>
+      <%= render partial: 'shoji_and_glass_fields', locals: { inner_sash:  f } %>
       <%= f.hidden_field :action, value: controller.action_name  %>
       <%= f.submit '保存' %>
     <% end %>

--- a/app/views/inner_sashes/shoji_and_glass.turbo_stream.erb
+++ b/app/views/inner_sashes/shoji_and_glass.turbo_stream.erb
@@ -1,4 +1,5 @@
+<%= turbo_stream_flash %>
 <%= turbo_stream.update 'inner-sash-data' do %>
   <%= render 'tabs' %>  
-  <%= render 'shoji_and_glass' %>
+  <%= render 'shoji_and_glass', inner_sash: @inner_sash %>
 <% end %>


### PR DESCRIPTION
## 概要
内窓の障子ガラス編集機能で、viewが正常に表示されなかったり、データが保存できない状態だったので修正

## やったこと
- ストロングパラメータの編集
- カラム指定の誤字修正
- フォームのパス変更
- renderにlocalsオプション追加

## やってないこと
- Low_Eとガラス色フォームの表示非表示

## 課題・疑問点

