### PR TITLE
現場一覧バグ修正

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,7 +3,7 @@ class SitesController < ApplicationController
           :construction_start_time, contractor_attributes: [:name]
 
   def index
-    @sites = current_user.sites.eager_load(:contractor, :site_memos).page(params[:page]).per(5)
+    @sites = current_user.sites.preload(:contractor, :site_memos).page(params[:page]).per(5)
   end
 
   def new

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -5,6 +5,7 @@ module SitesHelper
   end
 
   def check_order(site_memos)
+    return if site_memos.blank?
     order = []
     site_memos.each do |site_memo|
       # site_memoの子テーブルが出来次第ここに処理追加

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -5,9 +5,12 @@ module SitesHelper
   end
 
   def check_order(site_memos)
-    return "未発注" if site_memos.blank?
+    order = []
     site_memos.each do |site_memo|
-      return site_memo.order_i18n
+      # site_memoの子テーブルが出来次第ここに処理追加
+      order << site_memo.inner_sashes.pluck(:order) if site_memo.kind == 'inner_sash'
     end
+    return '発注済み' if order.all?{|n| n == 'ordered'}
+    return '未発注'
   end
 end


### PR DESCRIPTION
## 概要
site_memoテーブルのorderカラムを削除したため、現場一覧ページで発注状況が表示されないバグが発生していたので修正

## やったこと
- 発注状況を表示するヘルパーメソッドを修正
- 現場一覧を取得する際にpreloadを使用

## やってないこと

## 課題・疑問点
