### PR TITLE
[フロント]新規登録ページ（メールアドレス入力等）のデザイン追加

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -101,3 +101,8 @@ a{
   background-repeat: none;
   background-size: 38px 38px;
 }
+
+.submit-btn{
+  position: fixed;
+  bottom: 30px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -42,3 +42,7 @@
   background-color: var(--main-back);
   box-shadow: 0 3px 1px 1px var(--character);
 }
+
+.bg-danger{
+  background-color: var(--sign) !important;
+}

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-top-image">
-  <div class="container mx-auto">
+  <div class="container">
     <div class="row justify-content-center mb-5">
       <%= image_tag 'logo', class: 'logo col-md-8 col-lg-5' %>
     </div>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-image">
-  <div class="container mx-auto">
+  <div class="container">
     <div class="row justify-content-center">
       <%= image_tag 'logo', class: 'logo col-md-8 col-lg-5' %>
     </div>

--- a/app/views/sign_up/index.html.erb
+++ b/app/views/sign_up/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid bg-image">
-  <div class="container mx-auto">
+  <div class="container">
     <div class="row justify-content-center">
       <%= image_tag 'logo', class: 'logo col-md-8 col-lg-5' %>
     </div>

--- a/app/views/sign_up/step1.html.erb
+++ b/app/views/sign_up/step1.html.erb
@@ -1,22 +1,27 @@
-<%= form_with url: sign_up_step2_path, method: :get ,local: true do |f| %>
-  <div class="form-group">
-    <%= f.label :name, '名前' %><br />
-    <%= f.text_field :name, autocomplete: 'name', maxlength:'15', required: true %>
-  </div>
-  <div class="form-group">
-    <%= f.label :email, 'メールアドレス' %><br />
-    <%= f.email_field :email, autocomplete: 'email', required: true %>
-  </div>
-  <!--jsでパスワードが一致していないとき、警告-->
-  <div class="form-group">
-    <%= f.label :password, 'パスワード' %><br />
-    <%= f.password_field :password, autocomplete: 'new-password', required: true %>
-  </div>
-  <div class="form-group">
-    <%= f.label :password_confirmation, 'パスワード(確認用)' %><br />
-    <%= f.password_field :password_confirmation, autocomplete: 'new-password', required: true %>
-  </div>
-  <div class="form-group">
-    <%= f.submit '次へ' %>
-  </div>
-<% end %>
+<div class="bar mt-5">
+  ここに進捗バーが表示
+</div>
+<div class="container mt-5">
+  <%= form_with url: sign_up_step2_path, method: :get ,local: true, class: 'row justify-content-center' do |f| %>
+    <div class="col-11 mb-3">
+      <%= f.label :name, '名前', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
+      <%= f.text_field :name, class: 'form-control', autocomplete: 'name', maxlength:'15', required: true %>
+    </div>
+    <div class="col-11 mb-3">
+      <%= f.label :email, 'メールアドレス', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
+      <%= f.email_field :email, class: 'form-control', autocomplete: 'email', required: true %>
+    </div>
+    <!--jsでパスワードが一致していないとき、警告-->
+    <div class="col-11 mb-3">
+      <%= f.label :password, 'パスワード', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
+      <%= f.password_field :password, class: 'form-control', autocomplete: 'new-password', required: true %>
+    </div>
+    <div class="col-11 mb-3">
+      <%= f.label :password_confirmation, 'パスワード(確認用)', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
+      <%= f.password_field :password_confirmation, class: 'form-control', autocomplete: 'new-password', required: true %>
+    </div>
+    <div class="row justify-content-center p-3 mt-5">
+      <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-5 col-lg-3' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/sign_up/step1.html.erb
+++ b/app/views/sign_up/step1.html.erb
@@ -1,27 +1,27 @@
 <div class="bar mt-5">
   ここに進捗バーが表示
 </div>
-<div class="container mt-5">
+<div class="container" style="margin-top: 15vh;">
   <%= form_with url: sign_up_step2_path, method: :get ,local: true, class: 'row justify-content-center' do |f| %>
-    <div class="col-11 mb-3">
+    <div class="col-11 col-md-8 mb-3">
       <%= f.label :name, '名前', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.text_field :name, class: 'form-control', autocomplete: 'name', maxlength:'15', required: true %>
     </div>
-    <div class="col-11 mb-3">
+    <div class="col-11 col-md-8 mb-3">
       <%= f.label :email, 'メールアドレス', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.email_field :email, class: 'form-control', autocomplete: 'email', required: true %>
     </div>
     <!--jsでパスワードが一致していないとき、警告-->
-    <div class="col-11 mb-3">
+    <div class="col-11 col-md-8 mb-3">
       <%= f.label :password, 'パスワード', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.password_field :password, class: 'form-control', autocomplete: 'new-password', required: true %>
     </div>
-    <div class="col-11 mb-3">
+    <div class="col-11 col-md-8 mb-3">
       <%= f.label :password_confirmation, 'パスワード(確認用)', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.password_field :password_confirmation, class: 'form-control', autocomplete: 'new-password', required: true %>
     </div>
-    <div class="row justify-content-center p-3 mt-5">
-      <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-5 col-lg-3' %>
+    <div class="row justify-content-center p-3 submit-btn">
+      <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
     </div>
   <% end %>
 </div>

--- a/app/views/sign_up/step1.html.erb
+++ b/app/views/sign_up/step1.html.erb
@@ -3,20 +3,23 @@
 </div>
 <div class="container" style="margin-top: 15vh;">
   <%= form_with url: sign_up_step2_path, method: :get ,local: true, class: 'row justify-content-center' do |f| %>
-    <div class="col-11 col-md-8 mb-3">
+    <div class="col-11 col-md-8 col-lg-5 mb-3 mb-md-4">
       <%= f.label :name, '名前', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.text_field :name, class: 'form-control', autocomplete: 'name', maxlength:'15', required: true %>
     </div>
-    <div class="col-11 col-md-8 mb-3">
+    <div class="d-none d-lg-block col-lg-12"></div>
+    <div class="col-11 col-md-8 col-lg-5 mb-3 mb-md-4">
       <%= f.label :email, 'メールアドレス', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.email_field :email, class: 'form-control', autocomplete: 'email', required: true %>
     </div>
-    <!--jsでパスワードが一致していないとき、警告-->
-    <div class="col-11 col-md-8 mb-3">
+    <!--jsでパスワードが一致していないとき、警告を入れる予定-->
+    <div class="d-none d-lg-block col-lg-12"></div>
+    <div class="col-11 col-md-8 col-lg-5 mb-3 mb-md-4">
       <%= f.label :password, 'パスワード', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.password_field :password, class: 'form-control', autocomplete: 'new-password', required: true %>
     </div>
-    <div class="col-11 col-md-8 mb-3">
+    <div class="d-none d-lg-block col-lg-12"></div>
+    <div class="col-11 col-md-8 col-lg-5 mb-3 mb-md-4">
       <%= f.label :password_confirmation, 'パスワード(確認用)', class: 'form-label' %><span class="badge bg-danger ms-2">必須</span><br />
       <%= f.password_field :password_confirmation, class: 'form-control', autocomplete: 'new-password', required: true %>
     </div>


### PR DESCRIPTION
## 概要
新規登録ページのメールアドレス等を入力するページのデザインを整えた。レスポンシブ対応済み

## やったこと
- フォームのデザイン、レスポンシブ

## やってないこと
- 進捗状況を表すマップの表示

## 課題・疑問点

