### PR TITLE
一括発注機能修正

### DIFF
--- a/app/controllers/site_memos_controller.rb
+++ b/app/controllers/site_memos_controller.rb
@@ -9,13 +9,16 @@ class SiteMemosController < ApplicationController
     @order_key = get_opposite_order_key(site_memos: @site_memos)
   end
 
-  def update_bulk_order(site_id:, order:)
+  def update_bulk_order(site_id:, order:, devise:)
     @site = Site.preload(site_memos: :inner_sashes).find(site_id)
     @site_memos = @site.site_memos
     update_childs_order(site_memos: @site_memos, order: order)
     # あとでページネーション考える
     @order_key = get_opposite_order_key(site_memos: @site_memos)
     flash.now.notice = "全て#{ InnerSash.orders_i18n[order.to_sym]}にしました"
+    respond_to do |format|
+      format.turbo_stream { render "update_bulk_#{devise}_order" }
+    end
   end
 
   def new_step1(site_id:)

--- a/app/views/site_memos/_bulk_order_link.html.erb
+++ b/app/views/site_memos/_bulk_order_link.html.erb
@@ -1,4 +1,4 @@
-<%= link_to site_memos_update_bulk_order_path(site_id: @site.id, order: @order_key ),
+<%= link_to site_memos_update_bulk_order_path(site_id: @site.id, order: @order_key, devise: devise),
   class: 'btn btn-primary px-2 d-flex col-9 col-md-4 col-lg-10 col-xl-8 h-75',
   data: {turbo: true, turbo_method: :post, turbo_confirm: "全て#{InnerSash.orders_i18n[@order_key.to_sym]}にしますか？(表示されていないものも含みます)"} do %>
   <span class='col align-self-center'><%= "一括#{InnerSash.orders_i18n[@order_key.to_sym]}" %></span>

--- a/app/views/site_memos/index.html.erb
+++ b/app/views/site_memos/index.html.erb
@@ -20,7 +20,7 @@
         <% else %>
           <%= turbo_frame_tag 'site-memos-list', class: 'row justify-content-center' do %>
             <div class="submit-btn d-flex justify-content-start justify-content-md-center">
-              <%= render 'bulk_order_link' %>
+              <%= render 'bulk_order_link', devise: 'mobile' %>
             </div>
             <%= render @site_memos %>
           <% end %>
@@ -45,17 +45,19 @@
             <span class='col-7 align-self-center'>メモ追加</span>
           <% end %>
         </div>
-        <div class='col row justify-content-center'>
-          <%= render 'bulk_order_link' %>
-        </div>
+        <%= turbo_frame_tag 'bulk-order-link', class: 'col' do %>
+          <div class='row justify-content-center'>
+            <%= render 'bulk_order_link', devise: 'pc' %>
+          </div>
+        <% end %>
       </div>
-      <div>
+      <div class='index'>
         <% if @site_memos.blank? %>
-        <div class="text-center mt-5">
-          <p>メモはありません</p>
-        </div>
+          <div class="text-center mt-5">
+            <p>メモはありません</p>
+          </div>
         <% else %>
-          <%= turbo_frame_tag 'site-memos-list' do %>
+          <%= turbo_frame_tag 'site-memos-list-pc' do %>
             <%= render @site_memos %>
           <% end %>
         <% end %>

--- a/app/views/site_memos/update_bulk_mobile_order.turbo_stream.erb
+++ b/app/views/site_memos/update_bulk_mobile_order.turbo_stream.erb
@@ -1,7 +1,8 @@
+<!-- モバイル用 -->
 <%= turbo_stream_flash %>
 <%= turbo_stream.update "site-memos-list" do %>
   <div class="submit-btn d-flex justify-content-start justify-content-md-center">
-    <%= render 'bulk_order_link' %>
+    <%= render 'bulk_order_link', devise: 'mobile' %>
   </div>
   <%= render @site_memos %>
 <% end %>

--- a/app/views/site_memos/update_bulk_pc_order.turbo_stream.erb
+++ b/app/views/site_memos/update_bulk_pc_order.turbo_stream.erb
@@ -1,0 +1,11 @@
+<!-- pc用 -->
+<%= turbo_stream_flash %>
+<%= turbo_stream.update "bulk-order-link", class: 'col' do %>
+  <div class="row justify-content-center">
+    <%= render 'bulk_order_link', devise: 'pc' %>
+  </div>
+<% end %>
+
+<%= turbo_stream.update "site-memos-list-pc" do %>
+  <%= render @site_memos %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   get 'site_memos/index/:site_id', to: 'site_memos#index', as: :site_memos_index
-  post 'site_memos/update_bulk_order/:site_id/:order', to: 'site_memos#update_bulk_order', as: :site_memos_update_bulk_order
+  post 'site_memos/update_bulk_order/:site_id/:order/:devise', to: 'site_memos#update_bulk_order', as: :site_memos_update_bulk_order
   get 'site_memos/show_switcher/:kind/:id', to: 'site_memos#show_switcher', as: :site_memos_show_switcher
   get 'site_memos/new_step1/:site_id', to: 'site_memos#new_step1', as: :site_memos_new_step1
   post 'site_memos/form_switcher'


### PR DESCRIPTION
## 概要
pc用の一括発注機能で一覧ページのUIが崩れたので修正。turbo_stream.erbをモバイル用とpc用に分けた

## やったこと
- コントローラで各turbo_stream.erbに遷移するように修正
- mobile用、pc用のturbo_streaml.erbを作成

## やってないこと

## 課題・疑問点

