### PR TITLE
[フロント]内窓詳細ページのUIを追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -27,11 +27,13 @@
 .btn-primary{
   background-color: var(--main);
   border: none;
-  box-shadow: 0 3px 1px 1px var(--character);
+  box-shadow: 0 2px 1px 1px var(--character);
 }
 
 .btn-danger{
   background-color: var(--sign);
+  border: none;
+  box-shadow: 0 2px 1px 1px var(--character);
 }
 
 .btn-primary:hover{

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -10,3 +10,20 @@
 .unordered-label{
   background-color: var(--sign);
 }
+
+.height-frame-depth{
+  position: absolute;
+  top: 45%;
+  left: 36%;
+}
+
+.width-frame-depth{
+  position: absolute;
+  top: 47%;
+  left: 50%;
+}
+
+#opening{
+  width: 100%;
+  height: 30vh;
+}

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -2,3 +2,11 @@
   margin-top:56px;
   background-color: var(--side)
 }
+
+.ordered-label{
+  background-color: var(--main) ;
+}
+
+.unordered-label{
+  background-color: var(--sign);
+}

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -27,3 +27,11 @@
   width: 100%;
   height: 30vh;
 }
+
+.data-list{
+  height: 40px;
+}
+
+.data-list-2{
+  height: 80px;
+}

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -4,10 +4,6 @@
   background-color: var(--side)
 }
 
-.show-contents{
-  margin-top: 88px;
-}
-
 .ordered-label{
   background-color: var(--main) ;
 }

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,0 +1,4 @@
+.site-label{
+  margin-top:56px;
+  background-color: var(--side)
+}

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,6 +1,11 @@
 .site-label{
-  margin-top:56px;
+  position: fixed;
+  top:56px;
   background-color: var(--side)
+}
+
+.show-contents{
+  margin-top: 88px;
 }
 
 .ordered-label{

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -78,7 +78,8 @@ class InnerSashesController < ApplicationController
 
   def switch(template:, id:)
     @inner_sash = InnerSash.find(id)
-     # templateはbasic_info、shoji_and_glass、photo_and_othersのどれか
+     # templateはbasic_info、shoji_and_glass、photo_and_others
+     # opening_drawing h_cross_drawing w_cross_drawing　のどれか
     render "#{template}", content_type: 'text/vnd.turbo-stream.html'
   end
 

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -66,7 +66,6 @@ class InnerSashesController < ApplicationController
   end
 
   def destroy(id:)
-    p id
     inner_sash = InnerSash.find(id)
     inner_sash.destroy_last_with(site_memo: inner_sash.site_memo)
     redirect_to site_memos_index_path(site_id: inner_sash.site_memo.site_id), notice: "メモを削除しました"

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -66,9 +66,10 @@ class InnerSashesController < ApplicationController
   end
 
   def destroy(id:)
+    p id
     inner_sash = InnerSash.find(id)
     inner_sash.destroy_last_with(site_memo: inner_sash.site_memo)
-    redirect_to site_memos_index_path(site_id: site_memo.site_id), notice: "メモを削除しました"
+    redirect_to site_memos_index_path(site_id: inner_sash.site_memo.site_id), notice: "メモを削除しました"
   end
 
   def navigate_page(id:)

--- a/app/views/inner_sashes/_basic_info.html.erb
+++ b/app/views/inner_sashes/_basic_info.html.erb
@@ -34,7 +34,7 @@
                               inner_sash.height_right_size )%>  
         </span>
       </div>
-      <div class="row g-0 mt-4 align-items-center">
+      <div class="row g-0 mt-4 mt-md-5 align-items-center">
         <div class="col-3 mb-3">
           <% if @inner_sash.previous.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>

--- a/app/views/inner_sashes/_basic_info.html.erb
+++ b/app/views/inner_sashes/_basic_info.html.erb
@@ -1,19 +1,42 @@
 <%= turbo_frame_tag 'basic-info' do %>
-  タイプ<%= inner_sash.sash_type_i18n %>
-  色<%= inner_sash.color_i18n %>
-  障子枚数<%= inner_sash.number_of_shoji %>
-  吊り元<%= inner_sash.hanging_origin_i18n %>
-
-  <p>発注寸法</p>
-   <!-- W寸法 -->
-  W寸法<%= calc_order_size( inner_sash.width_up_size, 
-                      inner_sash.width_middle_size,
-                      inner_sash.width_down_size )%>
-
-  <!-- H寸法 -->
-  H寸法<%= calc_order_size( inner_sash.height_left_size,
-                      inner_sash.height_middle_size,
-                      inner_sash.height_right_size )%>
-
-  <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: inner_sash.id), data: {turbo_stream: true} %>
+  <div class='row text-center'>
+    <div class="col-12 row g-0 data-list align-items-center border-bottom">
+      <span class="col-6 fw-bold">タイプ</span>
+      <span class="col-6"><%= inner_sash.sash_type_i18n %></span>
+    </div>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center">
+      <span class="col-6 fw-bold">色</span>
+      <span class="col-6"><%= inner_sash.color_i18n %></span>
+    </div>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center">
+      <span class="col-6 fw-bold">障子枚数</span>
+      <span class="col-6"><%= inner_sash.number_of_shoji %></span>
+    </div>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center">
+      <span class="col-6 fw-bold">吊り元</span>
+      <span class="col-6"><%= inner_sash.hanging_origin_i18n %></span>
+    </div>
+    <p class='fw-bold mt-2 mb-2'>発注寸法</p>
+    <div class="col-12 row g-0 data-list-2">
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <span class='col-6 fw-bold'>W寸法</span>
+        <span class="col-6">
+          <%= calc_order_size( inner_sash.width_up_size, 
+                               inner_sash.width_middle_size,
+                               inner_sash.width_down_size )%>
+        </span>
+      </div>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <span class="col-6 fw-bold">H寸法</span>
+        <span class="col-6">
+          <%= calc_order_size( inner_sash.height_left_size,
+                              inner_sash.height_middle_size,
+                              inner_sash.height_right_size )%>  
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="btn btn-primary">
+    <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: inner_sash.id), data: {turbo_stream: true} %>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/_basic_info.html.erb
+++ b/app/views/inner_sashes/_basic_info.html.erb
@@ -43,7 +43,7 @@
           <% end %>
         </div>
         <div class="col-6 mb-3">
-          <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color w-100' %>
+          <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color col-11 col-lg-6' %>
         </div>
         <div class="col-3 mb-3">
           <% if @inner_sash.next.present? %>

--- a/app/views/inner_sashes/_basic_info.html.erb
+++ b/app/views/inner_sashes/_basic_info.html.erb
@@ -34,9 +34,25 @@
                               inner_sash.height_right_size )%>  
         </span>
       </div>
+      <div class="row g-0 mt-4 align-items-center">
+        <div class="col-3 mb-3">
+          <% if @inner_sash.previous.present? %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
+              <i class="bi bi-arrow-left-circle-fill h1"></i>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="col-6 mb-3">
+          <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color w-100' %>
+        </div>
+        <div class="col-3 mb-3">
+          <% if @inner_sash.next.present? %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
+              <i class="bi bi-arrow-right-circle-fill h1"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="btn btn-primary">
-    <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: inner_sash.id), data: {turbo_stream: true} %>
   </div>
 <% end %>

--- a/app/views/inner_sashes/_basic_info_fields.html.erb
+++ b/app/views/inner_sashes/_basic_info_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
-  <p>タイプ</p>
-  <%= inner_sash.select :sash_type, InnerSash.sash_types.keys.map{ |k| [I18n.t("enums.inner_sash.sash_type.#{k}"),k] }, {prompt: '選択してください'}, required: true %>
+  <%= inner_sash.label :sash_type, 'タイプ', class: 'form-label' %>
+  <%= inner_sash.select :sash_type, InnerSash.sash_types.keys.map{ |k| [I18n.t("enums.inner_sash.sash_type.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select' %>
 </div>
 <div class="form-group">
   <p>色</p>

--- a/app/views/inner_sashes/_drawing.html.erb
+++ b/app/views/inner_sashes/_drawing.html.erb
@@ -1,7 +1,7 @@
 <!--最終的にはcssでサイズ指定-->
-<canvas id="opening" width="500" height="500"></canvas>
-<canvas id="w-center-line"></canvas>
-<canvas id='h-center-line'></canvas>
+<canvas id="opening"></canvas>
+<%# <canvas id="w-center-line"></canvas>
+<canvas id='h-center-line'></canvas> %>
 
 <!-- w寸法 -->
 <%= inner_sash.width_up_size %>
@@ -13,3 +13,4 @@
 <%= inner_sash.height_left_size %>
 <%= inner_sash.height_middle_size %>
 <%= inner_sash.height_right_size %>
+

--- a/app/views/inner_sashes/_drawing.html.erb
+++ b/app/views/inner_sashes/_drawing.html.erb
@@ -2,9 +2,7 @@
 <canvas id="opening" width="500" height="500"></canvas>
 <canvas id="w-center-line"></canvas>
 <canvas id='h-center-line'></canvas>
-<!--pcは700角くらいがちょうどいい感じ-->
-<%= image_tag '図面1.png' , width: 500, height: 500 %>
-<%= image_tag '図面2.png', width: 500, height: 500 %>
+
 <!-- w寸法 -->
 <%= inner_sash.width_up_size %>
 <%= inner_sash.width_middle_size %>
@@ -15,7 +13,3 @@
 <%= inner_sash.height_left_size %>
 <%= inner_sash.height_middle_size %>
 <%= inner_sash.height_right_size %>
-
-<!-- 見込み寸法 -->
-<%= inner_sash.width_frame_depth %>
-<%= inner_sash.height_frame_depth %>

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,0 +1,11 @@
+<ul class="nav nav-tabs nav-fill">
+  <li class="nav-item">
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: 'nav-link active'%>
+  </li>
+  <li class="nav-item">
+    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: 'nav-link' %>
+  </li>
+  <li class="nav-item">
+    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: 'nav-link' %>
+  </li>
+</ul>

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,11 +1,14 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: 'nav-link active'%>
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: 'nav-link active',
+        data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: 'nav-link' %>
+    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: 'nav-link',
+        data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: 'nav-link' %>
+    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: 'nav-link', 
+        data: { turbo_stream: true } %>
   </li>
 </ul>

--- a/app/views/inner_sashes/_order_link.html.erb
+++ b/app/views/inner_sashes/_order_link.html.erb
@@ -1,3 +1,7 @@
 <%= link_to "#{InnerSash.orders_i18n[order_key.to_sym]}にする",
-    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "#{order_class}",
+    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-lg-none",
+    data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>
+
+    <%= link_to "#{InnerSash.orders_i18n[order_key.to_sym]}にする",
+    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-none d-lg-inline btn btn-primary py-0 px-3",
     data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>

--- a/app/views/inner_sashes/_order_link.html.erb
+++ b/app/views/inner_sashes/_order_link.html.erb
@@ -1,3 +1,3 @@
 <%= link_to "#{InnerSash.orders_i18n[order_key.to_sym]}にする",
-    inner_sashes_update_order_path(id: inner_sash.id, order: order_key),
+    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "#{order_class}",
     data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>

--- a/app/views/inner_sashes/_photo_and_others.html.erb
+++ b/app/views/inner_sashes/_photo_and_others.html.erb
@@ -1,9 +1,45 @@
 <%= turbo_frame_tag 'photo-and-others' do %>
-  平板<%= inner_sash.is_flat_bar ? "有" : "無" %>
-  アジャスト上枠<%= inner_sash.is_adjust ? "有" : "無" %>
-  <% inner_sash.photos.each do |photo| %>
-    <%= image_tag photo.file_name_url(:thumb) %>
-  <% end %>
-  <%= inner_sash.site_memo.remark %>
-  <%= link_to '編集', inner_sashes_switch_path(template: 'edit_photo_and_others', id: inner_sash.id), data: {turbo_stream: true} %>
+  <div class='row text-center'>
+    <div class="col-12 row g-0 data-list align-items-center border-bottom">
+      <span class="col-6 fw-bold">平板</span>
+      <span class="col-6"><%= inner_sash.is_flat_bar ? "有" : "無" %></span>
+    </div>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center">
+      <span class="col-6 fw-bold">アジャスト上枠</span>
+      <span class="col-6"><%= inner_sash.is_adjust ? "有" : "無" %></span>
+    </div>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center">
+      <span class="col-6 fw-bold">備考</span>
+      <span class="col-6"><%= inner_sash.site_memo.remark %></span>
+    </div>
+    <p class='fw-bold mt-2 mb-2'>写真</p>
+    <div class="col-12 row g-0 data-list-2">
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <% inner_sash.photos.each do |photo| %>
+          <div class="col-3">
+            <%= image_tag photo.file_name_url(:thumb) %>
+          </div>
+        <% end %>
+      </div>
+      <div class="row g-0 mt-4 mt-md-5 align-items-center">
+        <div class="col-3 mb-3">
+          <% if @inner_sash.previous.present? %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
+              <i class="bi bi-arrow-left-circle-fill h1"></i>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="col-6 mb-3">
+          <%= link_to '編集', inner_sashes_switch_path(template: 'edit_photo_and_others', id: inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color col-11 col-lg-6'%>
+        </div>
+        <div class="col-3 mb-3">
+          <% if @inner_sash.next.present? %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
+              <i class="bi bi-arrow-right-circle-fill h1"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/_shoji_and_glass.html.erb
+++ b/app/views/inner_sashes/_shoji_and_glass.html.erb
@@ -1,11 +1,50 @@
 <%= turbo_frame_tag 'shoji-and-glass' do %>
-  中桟<%= inner_sash.middle_frame_height %>
-  クレセント<%= inner_sash.key_height %>
-
-  <p>ガラス</p>
-  種類<%= inner_sash.glass_kind_i18n %>
-  色<%= inner_sash.glass_color_i18n %>
-  単板・複層<%= inner_sash.glass_thickness_i18n %>
-  Low-E<%= inner_sash.is_low_e ? "有" : "無" %>
-  <%= link_to '編集', inner_sashes_switch_path(template: 'edit_shoji_and_glass', id: inner_sash.id), data: {turbo_stream: true} %>
+  <div class='row text-center'>
+    <div class="col-12 row g-0 data-list align-items-center border-bottom">
+      <span class="col-6 fw-bold">中桟</span>
+      <span class="col-6"><%= inner_sash.middle_frame_height %></span>
+    </div>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center">
+      <span class="col-6 fw-bold">クレセント</span>
+      <span class="col-6"><%= inner_sash.key_height %></span>
+    </div>
+    <p class='fw-bold mt-2 mb-2'>ガラス</p>
+    <div class="col-12 row g-0 data-list-2">
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <span class='col-6 fw-bold'>種類</span>
+        <span class="col-6"><%= inner_sash.glass_kind_i18n %></span>
+      </div>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <span class="col-6 fw-bold">色</span>
+        <span class="col-6"><%= inner_sash.glass_color_i18n %></span>
+      </div>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <span class="col-6 fw-bold">単板・複層</span>
+        <span class="col-6"><%= inner_sash.glass_thickness_i18n %></span>
+      </div>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+        <span class="col-6 fw-bold">Low-E</span>
+        <span class="col-6"><%= inner_sash.is_low_e ? "有" : "無" %></span>
+      </div>
+      <div class="row g-0 mt-4 mt-md-5 align-items-center">
+        <div class="col-3 mb-3">
+          <% if @inner_sash.previous.present? %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
+              <i class="bi bi-arrow-left-circle-fill h1"></i>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="col-6 mb-3">
+          <%= link_to '編集', inner_sashes_switch_path(template: 'edit_shoji_and_glass', id: inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color col-11 col-lg-6' %>
+        </div>
+        <div class="col-3 mb-3">
+          <% if @inner_sash.next.present? %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
+              <i class="bi bi-arrow-right-circle-fill h1"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/_site_label.html.erb
+++ b/app/views/inner_sashes/_site_label.html.erb
@@ -1,0 +1,7 @@
+<div class="container-fluid">
+  <div class="site-label row text-center">
+    <p class='col my-1 fw-bold'><span class='d-none d-lg-inline'>元請：</span><%= @inner_sash.site_memo.site.contractor.name %></p>
+    <p class='col my-1 fw-bold'><span class='d-none d-lg-inline'>現場名：</span><%= @inner_sash.site_memo.site.name %></p>
+    <p class='col my-1 fw-bold'><span class='d-none d-lg-inline'>住所：</span><%= @inner_sash.site_memo.site.address %></p>
+  </div>
+</div>

--- a/app/views/inner_sashes/_site_label.html.erb
+++ b/app/views/inner_sashes/_site_label.html.erb
@@ -1,5 +1,5 @@
-<div class="container-fluid ">
-  <div class="site-label row text-center">
+<div class="container-fluid site-label">
+  <div class="row text-center">
     <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>元請：</span><%= @inner_sash.site_memo.site.contractor.name %></p>
     <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>現場名：</span><%= @inner_sash.site_memo.site.name %></p>
     <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>住所：</span><%= @inner_sash.site_memo.site.address %></p>

--- a/app/views/inner_sashes/_site_label.html.erb
+++ b/app/views/inner_sashes/_site_label.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <div class="site-label row text-center">
-    <p class='col my-1 fw-bold'><span class='d-none d-lg-inline'>元請：</span><%= @inner_sash.site_memo.site.contractor.name %></p>
-    <p class='col my-1 fw-bold'><span class='d-none d-lg-inline'>現場名：</span><%= @inner_sash.site_memo.site.name %></p>
-    <p class='col my-1 fw-bold'><span class='d-none d-lg-inline'>住所：</span><%= @inner_sash.site_memo.site.address %></p>
+    <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>元請：</span><%= @inner_sash.site_memo.site.contractor.name %></p>
+    <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>現場名：</span><%= @inner_sash.site_memo.site.name %></p>
+    <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>住所：</span><%= @inner_sash.site_memo.site.address %></p>
   </div>
 </div>

--- a/app/views/inner_sashes/_site_label.html.erb
+++ b/app/views/inner_sashes/_site_label.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container-fluid ">
   <div class="site-label row text-center">
     <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>元請：</span><%= @inner_sash.site_memo.site.contractor.name %></p>
     <p class='col my-1 fw-bold text-truncate'><span class='d-none d-lg-inline'>現場名：</span><%= @inner_sash.site_memo.site.name %></p>

--- a/app/views/inner_sashes/_tabs.html.erb
+++ b/app/views/inner_sashes/_tabs.html.erb
@@ -2,19 +2,22 @@
   <li class='nav-item'>
     <%= link_to inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), class: 'nav-link active',
         data: { turbo_stream: true } do %>
-      <p class="d-lg-none">寸法</p>
+      <p class="d-md-none">寸法</p>
+      <p class="d-none d-md-block">基本情報</p>
     <% end %>
   </li>
   <li class='nav-item'>
     <%= link_to inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id), class: 'nav-link',
         data: { turbo_stream: true } do %>
-      <p class="d-lg-none">障子</p>
+      <p class="d-md-none">障子</p>
+      <p class="d-none d-md-block">障子・ガラス</p>
     <% end %>
   </li>
   <li class='nav-item'>
     <%= link_to inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id), class: 'nav-link',
         data: { turbo_stream: true} do %>
-      <p class="d-lg-none">写真</p>
+      <p class="d-md-none">写真</p>
+      <p class="d-none d-md-block">写真・その他</p>
     <% end %>    
   </li>
 </ul>

--- a/app/views/inner_sashes/_tabs.html.erb
+++ b/app/views/inner_sashes/_tabs.html.erb
@@ -1,12 +1,20 @@
-<div id="basic-tab" class='data-tab is-active'>
-  <%= link_to '基本情報・枠', inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id),
-      data: { turbo_stream: true } %>
-</div>
-<div id="shoji-tab" class='data-tab'>
-  <%= link_to '障子・ガラス', inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id),
-      data: { turbo_stream: true } %>
-</div>
-<div id="photo-tab" class='data-tab'>
-  <%= link_to '写真・その他', inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id),
-      data: { turbo_stream: true} %>
-</div>
+<ul class="nav nav-tabs nav-fill">
+  <li class='nav-item'>
+    <%= link_to inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), class: 'nav-link active',
+        data: { turbo_stream: true } do %>
+      <p class="d-lg-none">寸法</p>
+    <% end %>
+  </li>
+  <li class='nav-item'>
+    <%= link_to inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id), class: 'nav-link',
+        data: { turbo_stream: true } do %>
+      <p class="d-lg-none">障子</p>
+    <% end %>
+  </li>
+  <li class='nav-item'>
+    <%= link_to inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id), class: 'nav-link',
+        data: { turbo_stream: true} do %>
+      <p class="d-lg-none">写真</p>
+    <% end %>    
+  </li>
+</ul>

--- a/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update 'drawing' do %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <div class="position-relative">
+    <%= image_tag 'h_cross_section', class: 'img-fluid' %>
+    <p class="width-frame-depth"><%= @inner_sash.width_frame_depth %></p>
+  </div>
+<% end %>

--- a/app/views/inner_sashes/navigate_page.turbo_stream.erb
+++ b/app/views/inner_sashes/navigate_page.turbo_stream.erb
@@ -5,8 +5,11 @@
   <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
 <% end %>
 <%= turbo_stream.update 'inner-sash-data-wrap' do %>
-  <%= render 'drawing', inner_sash: @inner_sash %>
-  <div id="inner-sash-data">
+  <%= turbo_frame_tag 'drawing' do %>
+    <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+    <%= render 'drawing', inner_sash: @inner_sash %>
+  <% end %>
+  <div id="inner-sash-data" class='mb-3'>
     <%= render 'tabs' %>
     <%= render 'basic_info', inner_sash: @inner_sash %>
   </div>

--- a/app/views/inner_sashes/navigate_page.turbo_stream.erb
+++ b/app/views/inner_sashes/navigate_page.turbo_stream.erb
@@ -1,15 +1,13 @@
 <%= turbo_stream.update'order-link' do %>
-  <%= render partial: 'layouts/order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+  <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
 <% end %>
 <%= turbo_stream.update 'inner-sash-delete' do %>
   <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
 <% end %>
 <%= turbo_stream.update 'inner-sash-data-wrap' do %>
-  <%= render 'drawing' %>
+  <%= render 'drawing', inner_sash: @inner_sash %>
   <div id="inner-sash-data">
     <%= render 'tabs' %>
-    <%= render 'basic_info' %>
+    <%= render 'basic_info', inner_sash: @inner_sash %>
   </div>
-  <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
-  <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
 <% end %>

--- a/app/views/inner_sashes/opening_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/opening_drawing.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.update 'drawing' do %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <%= render 'drawing', inner_sash: @inner_sash %>
+<% end %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -30,7 +30,7 @@
         <ul class="dropdown-menu mt-2">
           <li>
             <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
-              <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash, order_class: 'nil'} %>
+              <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
             <% end %>
           </li>
           <li>
@@ -42,10 +42,10 @@
       </div>
       <div class="col d-none d-lg-block">
         <%= turbo_frame_tag 'order-link'  do %>
-          <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash, order_class: 'btn btn-primary py-0 px-3'} %>
+          <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
         <% end %>
       </div>
-      <div class="col d-none d-lg-block">
+      <div id="inner-sash-delete" class="col d-none d-lg-block">
          <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'btn btn-danger px-4 py-0'%>
       </div>
     </div>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,29 +1,69 @@
 <%= render 'site_label' %>
-<div class="container">
-</div>
 
-<%= turbo_frame_tag 'order' do %>
-  <%= @inner_sash.order_i18n %>
-<% end %>
-<%= @inner_sash.room %>
-<p>内窓</p>
-<%= turbo_frame_tag 'order-link' do %>
-  <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
-<% end %>
-<div id="inner-sash-delete">
-  <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
-</div>
-<%= turbo_frame_tag 'inner-sash-data-wrap' do %>
+<section id="mobile">
+  <div class="container">
+  <div class="row d-md-none">
+    <div class="col <%= @inner_sash.order %>-label p-1 ps-3 mb-2">
+      <%= turbo_frame_tag 'order' do %>
+        <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+      <% end %>
+    </div>
+  </div>
+  <div class="row align-items-center text-center">
+    <div class="col">
+      <p class='m-0'><%= @inner_sash.room %></p>
+    </div>
+    <div class="col">
+      <p class='m-0'>内窓</p>
+    </div>
+    <div class="col">
+      <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
+    </div>
+    <div class="col-1 p-0 dropdown">
+      <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="bi bi-three-dots-vertical h1"></i>
+      </a>
+      <ul class="dropdown-menu">
+        <li>
+          <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
+            <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+          <% end %>
+        </li>
+        <li>
+          <p id="inner-sash-delete" class='dropdown-item m-0'>
+            <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
   <%= turbo_frame_tag 'drawing' do %>
+    <%= render 'drawing_tabs', inner_sash: @inner_sash %>
     <%= render 'drawing', inner_sash: @inner_sash %>
   <% end %>
-  <div id="inner-sash-data">
-    <%= render 'tabs' %>
-    <%= render 'basic_info', inner_sash: @inner_sash%>
+</section>
+    
+    
+    <%= turbo_frame_tag 'order-link' do %>
+      <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+    <% end %>
+    <div id="inner-sash-delete">
+      <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
+    </div>
   </div>
-  <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
-  <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
-<% end %>
+  <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
+    <%= turbo_frame_tag 'drawing' do %>
+      <%= render 'drawing', inner_sash: @inner_sash %>
+    <% end %>
+    <div id="inner-sash-data">
+      <%= render 'tabs' %>
+      <%= render 'basic_info', inner_sash: @inner_sash%>
+    </div>
+    <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
+    <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
+  <% end %>
+</div>
+
 <% content_for :js do %>
   <%= javascript_import_module_tag "draw_opening" %>
 <% end %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -2,49 +2,61 @@
 
 <section id="mobile">
   <div class="container">
-  <div class="row d-md-none">
-    <div class="col <%= @inner_sash.order %>-label p-1 ps-3 mb-2">
-      <%= turbo_frame_tag 'order' do %>
-        <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+    <div class="row d-md-none">
+      <div class="col <%= @inner_sash.order %>-label p-1 mb-2">
+        <%= turbo_frame_tag 'order' do %>
+          <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+        <% end %>
+      </div>
+    </div>
+    <div class="row align-items-center text-center mb-3">
+      <div class="col">
+        <p class='m-0'><%= @inner_sash.room %></p>
+      </div>
+      <div class="col">
+        <p class='m-0'>内窓</p>
+      </div>
+      <div class="col">
+        <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
+      </div>
+      <div class="col-1 p-0 dropdown">
+        <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="bi bi-three-dots-vertical h1"></i>
+        </a>
+        <ul class="dropdown-menu mt-2">
+          <li>
+            <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
+              <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+            <% end %>
+          </li>
+          <li>
+            <p id="inner-sash-delete" class='dropdown-item m-0'>
+              <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
+            </p>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
+      <%= turbo_frame_tag 'drawing' do %>
+        <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+        <%= render 'drawing', inner_sash: @inner_sash %>
       <% end %>
-    </div>
+      <div id="inner-sash-data mb-3">
+        <%= render 'tabs' %>
+        <%= render 'basic_info', inner_sash: @inner_sash%>
+      </div>
+      <div class="navigation mb-3">
+        <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
+        <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
+      </div>
+    <% end %>
   </div>
-  <div class="row align-items-center text-center">
-    <div class="col">
-      <p class='m-0'><%= @inner_sash.room %></p>
-    </div>
-    <div class="col">
-      <p class='m-0'>内窓</p>
-    </div>
-    <div class="col">
-      <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
-    </div>
-    <div class="col-1 p-0 dropdown">
-      <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-        <i class="bi bi-three-dots-vertical h1"></i>
-      </a>
-      <ul class="dropdown-menu">
-        <li>
-          <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
-            <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
-          <% end %>
-        </li>
-        <li>
-          <p id="inner-sash-delete" class='dropdown-item m-0'>
-            <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
-          </p>
-        </li>
-      </ul>
-    </div>
-  </div>
-  <%= turbo_frame_tag 'drawing' do %>
-    <%= render 'drawing_tabs', inner_sash: @inner_sash %>
-    <%= render 'drawing', inner_sash: @inner_sash %>
-  <% end %>
 </section>
     
-    
-    <%= turbo_frame_tag 'order-link' do %>
+
+<section id="pc" class='d-none d-lg-block'>
+  <%= turbo_frame_tag 'order-link' do %>
       <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
     <% end %>
     <div id="inner-sash-delete">
@@ -62,7 +74,7 @@
     <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
     <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
   <% end %>
-</div>
+</section>
 
 <% content_for :js do %>
   <%= javascript_import_module_tag "draw_opening" %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,8 +1,6 @@
-<p>内窓詳細</p>
-
-<p>元請</p><%= @inner_sash.site_memo.site.contractor.name %>
-<p>現場名</p><%= @inner_sash.site_memo.site.name %>
-<p>住所</p><%= @inner_sash.site_memo.site.address %><br/>
+<%= render 'site_label' %>
+<div class="container">
+</div>
 
 <%= turbo_frame_tag 'order' do %>
   <%= @inner_sash.order_i18n %>
@@ -29,3 +27,5 @@
 <% content_for :js do %>
   <%= javascript_import_module_tag "draw_opening" %>
 <% end %>
+
+<%= stylesheet_link_tag "show", "data-turbo-track": "reload" %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,8 +1,7 @@
-<%= render 'site_label' %>
-
 <section id="mobile">
-  <div class="container">
-    <div class="row d-md-none">
+  <%= render 'site_label' %>
+  <div class="container show-contents">
+    <div class="row d-sm-none">
       <div class="col <%= @inner_sash.order %>-label p-1 mb-2">
         <%= turbo_frame_tag 'order' do %>
           <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
@@ -15,6 +14,11 @@
       </div>
       <div class="col">
         <p class='m-0'>内窓</p>
+      </div>
+      <div class="col-2 d-none d-sm-block">
+        <%= turbo_frame_tag 'order', class: "badge #{@inner_sash.order}-label py-1 px-3" do %>
+          <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+        <% end %>
       </div>
       <div class="col">
         <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -42,7 +42,7 @@
         <%= render 'drawing_tabs', inner_sash: @inner_sash %>
         <%= render 'drawing', inner_sash: @inner_sash %>
       <% end %>
-      <div id="inner-sash-data mb-3">
+      <div id="inner-sash-data" class='mb-3'>
         <%= render 'tabs' %>
         <%= render 'basic_info', inner_sash: @inner_sash%>
       </div>
@@ -69,7 +69,7 @@
     <% end %>
     <div id="inner-sash-data">
       <%= render 'tabs' %>
-      <%= render 'basic_info', inner_sash: @inner_sash%>
+      <%= render 'basic_info', inner_sash: @inner_sash %>
     </div>
     <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
     <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -46,10 +46,6 @@
         <%= render 'tabs' %>
         <%= render 'basic_info', inner_sash: @inner_sash%>
       </div>
-      <div class="navigation mb-3">
-        <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
-        <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
-      </div>
     <% end %>
   </div>
 </section>
@@ -71,8 +67,19 @@
       <%= render 'tabs' %>
       <%= render 'basic_info', inner_sash: @inner_sash %>
     </div>
-    <%= link_to '次', inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? %>
-    <%= link_to '前', inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? %>
+    <div class="position-relative">
+      <div class="row justify-content-center mt-4 mb-5 ">
+        <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary col-6' %>
+      </div>
+      <div class="navigation">
+        <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? do %>
+
+        <% end %>
+        <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? do %>
+
+        <% end %>
+      </div>
+    </div>
   <% end %>
 </section>
 

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,6 +1,6 @@
 <section id="mobile">
   <%= render 'site_label' %>
-  <div class="container show-contents">
+  <div class="container" style='margin-top:88px;'>
     <div class="row d-sm-none">
       <div class="col <%= @inner_sash.order %>-label p-1 mb-2">
         <%= turbo_frame_tag 'order' do %>
@@ -8,7 +8,7 @@
         <% end %>
       </div>
     </div>
-    <div class="row align-items-center text-center mb-3">
+    <div class="row align-items-center text-center mb-3" style='height:60px;'>
       <div class="col">
         <p class='m-0'><%= @inner_sash.room %></p>
       </div>
@@ -23,14 +23,14 @@
       <div class="col">
         <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
       </div>
-      <div class="col-1 p-0 dropdown">
+      <div class="col-1 p-0 dropdown d-lg-none">
         <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
           <i class="bi bi-three-dots-vertical h1"></i>
         </a>
         <ul class="dropdown-menu mt-2">
           <li>
             <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
-              <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+              <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash, order_class: 'nil'} %>
             <% end %>
           </li>
           <li>
@@ -39,6 +39,14 @@
             </p>
           </li>
         </ul>
+      </div>
+      <div class="col d-none d-lg-block">
+        <%= turbo_frame_tag 'order-link'  do %>
+          <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash, order_class: 'btn btn-primary py-0 px-3'} %>
+        <% end %>
+      </div>
+      <div class="col d-none d-lg-block">
+         <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'btn btn-danger px-4 py-0'%>
       </div>
     </div>
     <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
@@ -52,39 +60,6 @@
       </div>
     <% end %>
   </div>
-</section>
-    
-
-<section id="pc" class='d-none d-lg-block'>
-  <%= turbo_frame_tag 'order-link' do %>
-      <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
-    <% end %>
-    <div id="inner-sash-delete">
-      <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
-    </div>
-  </div>
-  <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
-    <%= turbo_frame_tag 'drawing' do %>
-      <%= render 'drawing', inner_sash: @inner_sash %>
-    <% end %>
-    <div id="inner-sash-data">
-      <%= render 'tabs' %>
-      <%= render 'basic_info', inner_sash: @inner_sash %>
-    </div>
-    <div class="position-relative">
-      <div class="row justify-content-center mt-4 mb-5 ">
-        <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary col-6' %>
-      </div>
-      <div class="navigation">
-        <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} if @inner_sash.previous.present? do %>
-
-        <% end %>
-        <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post} if @inner_sash.next.present? do %>
-
-        <% end %>
-      </div>
-    </div>
-  <% end %>
 </section>
 
 <% content_for :js do %>

--- a/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update 'drawing' do %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <div class="position-relative">
+    <%= image_tag 'w_cross_section', class: 'img-fluid'%>
+    <p class='height-frame-depth'><%= @inner_sash.height_frame_depth %></p>
+  </div>
+<% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -19,4 +19,5 @@ Rails.application.config.assets.precompile += %w(
 
   top.css
   index.css
+  show.css
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,31 +6,31 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 # 現場まとめて生成する
-20.times do |n|
-  name = Faker::Name.name
-  address = Faker::Address.city
-  user_id = 2
-  contractor_id = 2
-  Site.create!(name: name,
-                  address: address,
-                  user_id: user_id,
-                  contractor_id: contractor_id)
-end
-
-
-# size = rand(1..9999)
-# room = Faker::House.room
-# kind = 'inner_sash'
-# site_memo = SiteMemo.create!(site_id: 10 , kind: kind)
 # 20.times do |n|
-#   InnerSash.create!(width_up_size: size,
-#                     width_middle_size: size,
-#                     width_down_size: size,
-#                     height_left_size: size,
-#                     height_middle_size: size,
-#                     height_right_size: size,
-#                     width_frame_depth: size,
-#                     height_frame_depth: size,
-#                     room: room,
-#                     site_memo_id: site_memo.id)
+#   name = Faker::Name.name
+#   address = Faker::Address.city
+#   user_id = 2
+#   contractor_id = 2
+#   Site.create!(name: name,
+#                   address: address,
+#                   user_id: user_id,
+#                   contractor_id: contractor_id)
 # end
+
+
+size = rand(1..9999)
+room = Faker::House.room
+kind = 'inner_sash'
+site_memo = SiteMemo.create!(site_id: 2, kind: kind)
+20.times do |n|
+  InnerSash.create!(width_up_size: size,
+                    width_middle_size: size,
+                    width_down_size: size,
+                    height_left_size: size,
+                    height_middle_size: size,
+                    height_right_size: size,
+                    width_frame_depth: size,
+                    height_frame_depth: size,
+                    room: room,
+                    site_memo_id: site_memo.id)
+end


### PR DESCRIPTION
## 概要
内窓詳細ページのUIを整えた。レスポンシブに対応。

## やったこと
- 詳細ページのUI
- タブで図面切り替え
- タブで情報切り替え
- 各turbo_stream.erbのUI
  - basic_info
  - photo_and_others
  - shoji_and_glass

## やってないこと
- 削除した時のバグ修正

## 課題・疑問点

