### PR TITLE
[フロント]現場メモ新規作成ページhtml内のpc用削除

### DIFF
--- a/app/views/inner_sashes/_basic_info_fields.html.erb
+++ b/app/views/inner_sashes/_basic_info_fields.html.erb
@@ -1,56 +1,34 @@
-<section id="mobile" class='d-lg-none'>
-  <div class='row justify-content-center position-relative mt-3'>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :sash_type, 'タイプ', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :sash_type, InnerSash.sash_types.keys.map{ |k| [I18n.t("enums.inner_sash.sash_type.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :color, '色', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :color, InnerSash.colors.keys.map{ |k| [I18n.t("enums.inner_sash.color.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :number_of_shoji, '障子数', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :number_of_shoji, (1..2).each { |i| ["#{i}",i]}, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :hanging_origin, '吊り元', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :hanging_origin, InnerSash.hanging_origins.keys.map{ |k| [I18n.t("enums.inner_sash.hanging_origin.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-      </span>
-    </div>
-  </div>
-</section>
-
-<section id='pc' class='d-none d-lg-block'>
-  <div class="row border-bottom position-relative p-3 text-center sites-table" style='height:80px;'>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.text_field :room, required: true, class: 'border-0' %>
-    </div>
-    <div class="col d-flex justify-content-center">
+<div class='row justify-content-center position-relative mt-3'>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :sash_type, 'タイプ', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
       <%= inner_sash.select :sash_type, InnerSash.sash_types.keys.map{ |k| [I18n.t("enums.inner_sash.sash_type.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.select :color, InnerSash.colors.keys.map{ |k| [I18n.t("enums.inner_sash.color.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.select :number_of_shoji, (1..2).each { |i| ["#{i}",i]}, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.select :hanging_origin, InnerSash.hanging_origins.keys.map{ |k| [I18n.t("enums.inner_sash.hanging_origin.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
-    </div>
+    </span>
   </div>
-</section>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :color, '色', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.select :color, InnerSash.colors.keys.map{ |k| [I18n.t("enums.inner_sash.color.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
+    </span>
+  </div>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :number_of_shoji, '障子数', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.select :number_of_shoji, (1..2).each { |i| ["#{i}",i]}, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
+    </span>
+  </div>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :hanging_origin, '吊り元', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.select :hanging_origin, InnerSash.hanging_origins.keys.map{ |k| [I18n.t("enums.inner_sash.hanging_origin.#{k}"),k] }, {prompt: '選択してください'}, required: true, class: 'form-select basic-form' %>
+    </span>
+  </div>
+</div>

--- a/app/views/inner_sashes/_shoji_and_glass_fields.html.erb
+++ b/app/views/inner_sashes/_shoji_and_glass_fields.html.erb
@@ -1,76 +1,49 @@
-<section id="mobile" class='d-lg-none'>
-  <div class='row justify-content-center position-relative mt-3'>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :glass_thickness, '厚み', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :glass_thickness, InnerSash.glass_thicknesses.keys.map{ |k| [I18n.t("enums.inner_sash.glass_thickness.#{k}"),k] },{}, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :glass_kind, '種類', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :glass_kind, InnerSash.glass_kinds.keys.map{ |k| [I18n.t("enums.inner_sash.glass_kind.#{k}"),k] }, {}, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :glass_color, 'ガラス色', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :glass_color, InnerSash.glass_colors.keys.map{ |k| [I18n.t("enums.inner_sash.glass_color.#{k}"),k] }, {}, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :is_low_e, 'Low_E', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.select :is_low_e ,[['有',1],['無',0]], {}, class: 'form-select basic-form' %>
-      </span>
-    </div>
-    <div class='col-11 row border-index p-1 mb-3' style='height:60px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :key_height, '鍵高さ', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.number_field :key_height, required: true, class: 'form-control basic-form' %>
-      </span>
-    </div><div class='col-11 row border-index p-1 mb-3' style='height:60px;'>
-      <span class='col-4'>
-        <%= inner_sash.label :middle_frame_height, '中桟高さ', class: 'form-label' %>
-      </span>
-      <span class='col-7'>
-        <%= inner_sash.number_field :middle_frame_height, required: true, class: 'form-control basic-form' %>
-      </span>
-    </div>
-  </div>
-</section>
-
-<section id='pc' class='d-none d-lg-block'>
-  <div class="row border-bottom position-relative p-3 text-center sites-table" style='height:80px;'>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.text_field :room, required: true, class: 'border-0' %>
-    </div>
-    <div class="col d-flex justify-content-center">
+<div class='row justify-content-center position-relative mt-3'>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :glass_thickness, '厚み', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
       <%= inner_sash.select :glass_thickness, InnerSash.glass_thicknesses.keys.map{ |k| [I18n.t("enums.inner_sash.glass_thickness.#{k}"),k] },{}, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.select :glass_kind, InnerSash.glass_kinds.keys.map{ |k| [I18n.t("enums.inner_sash.glass_kind.#{k}"),k] }, {}, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.select :glass_color, InnerSash.glass_colors.keys.map{ |k| [I18n.t("enums.inner_sash.glass_color.#{k}"),k] }, {}, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.select :is_low_e ,[['有',1],['無',0]], {}, class: 'form-select basic-form' %>
-    </div>
-    <div class="col d-flex justify-content-center">
-      <%= inner_sash.number_field :key_height, required: true, class: 'form-control basic-form' %>
-    </div><div class="col d-flex justify-content-center">
-      <%= inner_sash.number_field :middle_frame_height, required: true, class: 'form-control basic-form' %>
-    </div>
+    </span>
   </div>
-</section>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :glass_kind, '種類', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.select :glass_kind, InnerSash.glass_kinds.keys.map{ |k| [I18n.t("enums.inner_sash.glass_kind.#{k}"),k] }, {}, class: 'form-select basic-form' %>
+    </span>
+  </div>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :glass_color, 'ガラス色', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.select :glass_color, InnerSash.glass_colors.keys.map{ |k| [I18n.t("enums.inner_sash.glass_color.#{k}"),k] }, {}, class: 'form-select basic-form' %>
+    </span>
+  </div>
+  <div class='col-11 row border-index p-1 mb-3' style='height:40px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :is_low_e, 'Low_E', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.select :is_low_e ,[['有',1],['無',0]], {}, class: 'form-select basic-form' %>
+    </span>
+  </div>
+  <div class='col-11 row border-index p-1 mb-3' style='height:60px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :key_height, '鍵高さ', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.number_field :key_height, required: true, class: 'form-control basic-form' %>
+    </span>
+  </div><div class='col-11 row border-index p-1 mb-3' style='height:60px;'>
+    <span class='col-4'>
+      <%= inner_sash.label :middle_frame_height, '中桟高さ', class: 'form-label' %>
+    </span>
+    <span class='col-7'>
+      <%= inner_sash.number_field :middle_frame_height, required: true, class: 'form-control basic-form' %>
+    </span>
+  </div>
+</div>

--- a/app/views/inner_sashes/new_step3.html.erb
+++ b/app/views/inner_sashes/new_step3.html.erb
@@ -3,57 +3,36 @@
   <%= render 'new_added_index' %>
 </div>
 
-<!-- モバイル用 -->
-<section id="mobile" class='d-lg-none'>
-  <div class="container" style="margin-top:15vh";>  
-    <div style="margin-top: 5vh;">
-      <%= form_with model: @site_memo, url: inner_sashes_new_append_basic_info_path, local: true, class: "row justify-content-center" do |f| %>
-        <%= render 'layouts/alert', obj: f.object %>
-        <%= f.fields_for :inner_sashes do |inner_sash| %>
-          <div class="mb-4 d-lg-none col-12 col-md-6">
-            <div class="card card-custom">
-              <div class="card-body">
-                <div class="row mb-1">
-                  <div class="form_group">
-                    <h5 class="col-7 card-title text-truncate">
-                      <%= inner_sash.text_field :room, required: true, class: 'border-0' %>
-                    </h5>
-                  </div>
-                  <%= render 'basic_info_fields', inner_sash: inner_sash %>
-                </div>
-              </div>
-            </div>
-          </div>
-        <% end %>
-        <div class="row justify-content-center p-3 mb-3 mb-lg-5">
-          <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<!-- pc用 -->
-<section id="pc" class='d-none d-lg-block'>
-  <div class="container mt-5">  
-    <div class="row g-0 border-bottom border-custom p-3 text-center">
-      <h5 class="col fw-bold">部屋</h5>
-      <h5 class="col fw-bold">タイプ</h5>
-      <h5 class="col fw-bold">色</h5>
-      <h5 class="col fw-bold">障子枚数</h5>
-      <h5 class="col fw-bold">吊り元</h5>
-    </div>
+<div class="container" style="margin-top:15vh";>  
+  <div style="margin-top: 5vh;">
     <%= form_with model: @site_memo, url: inner_sashes_new_append_basic_info_path, local: true, class: "row justify-content-center" do |f| %>
       <%= render 'layouts/alert', obj: f.object %>
       <%= f.fields_for :inner_sashes do |inner_sash| %>
-        <%= render 'basic_info_fields', inner_sash: inner_sash %>
+        <div class="mb-4 col-12 col-md-6 col-lg-4">
+          <div class="card card-custom">
+            <div class="card-body">
+              <div class="row mb-1">
+                <div class="form_group">
+                  <h5 class="col-7 card-title text-truncate">
+                    <%= inner_sash.text_field :room, required: true, class: 'border-0' %>
+                  </h5>
+                </div>
+                <%= render 'basic_info_fields', inner_sash: inner_sash %>
+              </div>
+            </div>
+          </div>
+        </div>
       <% end %>
-      <div class="row justify-content-center p-3 mb-3 mb-lg-5 mt-3">
+      <div class="col text-center mt-1">
+        <%= f.label :remark, '備考', class: 'form-label h5' %>
+        <%= f.text_area :remark, class: 'form-control', placeholder: '現場の気になったことを記入' %>
+      </div>
+      <div class="row justify-content-center p-3 mb-3 mb-lg-5">
         <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
       </div>
     <% end %>
   </div>
-</section>
+</div>
 
 <%= stylesheet_link_tag "new", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "index", "data-turbo-track": "reload" %>

--- a/app/views/inner_sashes/new_step4.html.erb
+++ b/app/views/inner_sashes/new_step4.html.erb
@@ -3,59 +3,36 @@
   <%= render 'new_added_index' %>
 </div>
 
-<!-- モバイル用 -->
-<section id="mobile" class='d-lg-none'>
-  <div class="container" style="margin-top:15vh";>  
-    <div style="margin-top: 5vh;">
-      <%= form_with model: @site_memo, url: inner_sashes_new_append_shoji_and_glass_path, local: true, class: "row justify-content-center" do |f| %>
-        <%= render 'layouts/alert', obj: f.object %>
-        <%= f.fields_for :inner_sashes do |inner_sash| %>
-          <div class="mb-4 d-lg-none col-12 col-md-6">
-            <div class="card card-custom">
-              <div class="card-body">
-                <div class="row mb-1">
-                  <div class="form_group">
-                    <h5 class="col-7 card-title text-truncate">
-                      <%= inner_sash.text_field :room, required: true, class: 'border-0' %>
-                    </h5>
-                  </div>
-                  <%= render 'shoji_and_glass_fields', inner_sash: inner_sash %>
-                </div>
-              </div>
-            </div>
-          </div>
-        <% end %>
-        <div class="row justify-content-center p-3 mb-3 mb-lg-5">
-          <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<!-- pc用 -->
-<section id="pc" class='d-none d-lg-block'>
-  <div class="container mt-5">  
-    <div class="row g-0 border-bottom border-custom p-3 text-center">
-      <h5 class="col fw-bold">部屋名</h5>
-      <h5 class="col fw-bold">厚み</h5>
-      <h5 class="col fw-bold">種類</h5>
-      <h5 class="col fw-bold">ガラス色</h5>
-      <h5 class="col fw-bold">Low-E</h5>
-      <h5 class="col fw-bold">鍵高さ</h5>
-      <h5 class="col fw-bold">中桟高さ</h5>
-    </div>
+<div class="container" style="margin-top:15vh";>  
+  <div style="margin-top: 5vh;">
     <%= form_with model: @site_memo, url: inner_sashes_new_append_shoji_and_glass_path, local: true, class: "row justify-content-center" do |f| %>
       <%= render 'layouts/alert', obj: f.object %>
       <%= f.fields_for :inner_sashes do |inner_sash| %>
-        <%= render 'shoji_and_glass_fields', inner_sash: inner_sash %>
+        <div class="mb-4 col-12 col-md-6 col-lg-4">
+          <div class="card card-custom">
+            <div class="card-body">
+              <div class="row mb-1">
+                <div class="form_group">
+                  <h5 class="col-7 card-title text-truncate">
+                    <%= inner_sash.text_field :room, required: true, class: 'border-0' %>
+                  </h5>
+                </div>
+                <%= render 'shoji_and_glass_fields', inner_sash: inner_sash %>
+              </div>
+            </div>
+          </div>
+        </div>
       <% end %>
-      <div class="row justify-content-center p-3 mb-3 mb-lg-5 mt-3">
+      <div class="col text-center mt-1">
+        <%= f.label :remark, '備考', class: 'form-label h5' %>
+        <%= f.text_area :remark, class: 'form-control', placeholder: '現場の気になったことを記入' %>
+      </div>
+      <div class="row justify-content-center p-3 mb-3 mb-lg-5">
         <%= f.submit '次へ', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
       </div>
     <% end %>
   </div>
-</section>
+</div>
 
 <%= stylesheet_link_tag "new", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "index", "data-turbo-track": "reload" %>


### PR DESCRIPTION
## 概要
各ページの同一htmlファイル内にモバイル用とpc用を分けて書いていたが、2重に読み込まれてしまったり書き方が一般的ではないのでpc用を削除

## やったこと
- pc用のhtml削除
  - 基本情報登録ページ
  - 障子ガラス登録ページ

- 各ページに備考欄の追加

## やってないこと

## 課題・疑問点

