### PR TITLE
現場新規作成機能リファクタリング（写真データN+1問題）

### DIFF
--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -51,7 +51,7 @@ class InnerSashesController < ApplicationController
   def new_comfirmation
     @site_memo.update_status(action: action_name)
     # @site_memo = SiteMemo.preload(inner_sashes: :photos).find_by(site_id: session[:site_id], kind: 'inner_sash')
-    @inner_sashes = @site_memo.inner_sashes
+    load_inner_sashes
   end
   
   def show(id:)
@@ -112,7 +112,7 @@ private
   end
 
   def load_inner_sashes
-    @inner_sashes = InnerSash.eager_load(:site_memo).where(site_memo: {kind: 'inner_sash', site_id: session[:site_id]})
+    @inner_sashes = InnerSash.eager_load(:site_memo, :photos).where(site_memo: {kind: 'inner_sash', site_id: session[:site_id]})
   end
 
   def set_site_memo

--- a/app/views/inner_sashes/new_step2.html.erb
+++ b/app/views/inner_sashes/new_step2.html.erb
@@ -1,5 +1,6 @@
 <%= render 'site_label', parent: @site_memo.site %>
 <%= render 'new_added_index' %>
+
 <div class="container mt-5">
   <%= turbo_frame_tag 'inner-sash-size-form' do %>
     <%= form_with model: @inner_sash, url: inner_sashes_new_append_room_path, data: { turbo_stream: true }, class: 'row justify-content-center' do |inner_sash|%>

--- a/app/views/inner_sashes/new_step3.html.erb
+++ b/app/views/inner_sashes/new_step3.html.erb
@@ -1,9 +1,7 @@
 <%= render 'site_label', parent: @site_memo.site %>
-<div class="d-none d-lg-block">
-  <%= render 'new_added_index' %>
-</div>
+<%= render 'new_added_index' %>
 
-<div class="container" style="margin-top:15vh";>  
+<div class="container" style="margin-top:10vh";>  
   <div style="margin-top: 5vh;">
     <%= form_with model: @site_memo, url: inner_sashes_new_append_basic_info_path, local: true, class: "row justify-content-center" do |f| %>
       <%= render 'layouts/alert', obj: f.object %>

--- a/app/views/inner_sashes/new_step4.html.erb
+++ b/app/views/inner_sashes/new_step4.html.erb
@@ -1,9 +1,7 @@
 <%= render 'site_label', parent: @site_memo.site %>
-<div class="d-none d-lg-block">
-  <%= render 'new_added_index' %>
-</div>
+<%= render 'new_added_index' %>
 
-<div class="container" style="margin-top:15vh";>  
+<div class="container" style="margin-top:10vh";>  
   <div style="margin-top: 5vh;">
     <%= form_with model: @site_memo, url: inner_sashes_new_append_shoji_and_glass_path, local: true, class: "row justify-content-center" do |f| %>
       <%= render 'layouts/alert', obj: f.object %>

--- a/app/views/inner_sashes/new_step5.html.erb
+++ b/app/views/inner_sashes/new_step5.html.erb
@@ -1,6 +1,7 @@
 <%= render 'site_label', parent: @site_memo.site %>
+<%= render 'new_added_index' %>
 
-<div class="container" style='margin-top:15vh;'>
+<div class="container" style='margin-top:10vh;'>
   <%= form_with model: @site_memo, url: inner_sashes_new_append_photo_and_others_path, local: true, class: "row justify-content-center" do |f| %>
     <%= render 'layouts/alert', obj: f.object %>
     <%= f.fields_for :inner_sashes do |inner_sash| %>


### PR DESCRIPTION
## 概要
現場新規作成機能の登録済一覧を表示する際の、写真枚数カウントでN+1問題が起きていたので修正

## やったこと
- load_inner_sashesでデータを取る際に写真モデルも追加
- レイアウトの微調整

## やってないこと

## 課題・疑問点
