### PR TITLE
[フロント]現場メモ詳細のUI修正

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -26,7 +26,3 @@
 .data-list{
   height: 40px;
 }
-
-.data-list-2{
-  height: 80px;
-}

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -6,15 +6,15 @@
   background-color: var(--sign);
 }
 
-.height-frame-depth{
+.height-size{
   position: absolute;
   top: 45%;
-  left: 36%;
+  left: 43%;
 }
 
-.width-frame-depth{
+.width-size{
   position: absolute;
-  top: 47%;
+  top: 40%;
   left: 50%;
 }
 
@@ -29,4 +29,11 @@
 
 .active{
   background-color: var(--thin-sub) !important;
+}
+
+.cross-image{
+  display: block;
+  margin: auto;
+  max-width: 60%;
+  max-height: 60%;
 }

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -26,3 +26,7 @@
 .data-list{
   height: 40px;
 }
+
+.active{
+  background-color: var(--thin-sub) !important;
+}

--- a/app/helpers/inner_sashes_helper.rb
+++ b/app/helpers/inner_sashes_helper.rb
@@ -7,4 +7,8 @@ module InnerSashesHelper
     return 1 if boolean
     return 0
   end
+
+  def is_active(tab_name)
+    return 'active' if tab_name.present?
+  end
 end

--- a/app/views/inner_sashes/_basic_info.html.erb
+++ b/app/views/inner_sashes/_basic_info.html.erb
@@ -1,51 +1,51 @@
 <%= turbo_frame_tag 'basic-info' do %>
   <div class='row text-center'>
-    <div class="col-12 row g-0 data-list align-items-center border-bottom">
-      <span class="col-6 fw-bold">タイプ</span>
-      <span class="col-6"><%= inner_sash.sash_type_i18n %></span>
+    <div class="col-12 row g-0 data-list align-items-center justify-content-center border-bottom">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">タイプ</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.sash_type_i18n %></span>
     </div>
-    <div class="col-12 row border-bottom g-0 data-list align-items-center">
-      <span class="col-6 fw-bold">色</span>
-      <span class="col-6"><%= inner_sash.color_i18n %></span>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center justify-content-center">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">色</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.color_i18n %></span>
     </div>
-    <div class="col-12 row border-bottom g-0 data-list align-items-center">
-      <span class="col-6 fw-bold">障子枚数</span>
-      <span class="col-6"><%= inner_sash.number_of_shoji %></span>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center justify-content-center">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">障子枚数</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.number_of_shoji %></span>
     </div>
-    <div class="col-12 row border-bottom g-0 data-list align-items-center">
-      <span class="col-6 fw-bold">吊り元</span>
-      <span class="col-6"><%= inner_sash.hanging_origin_i18n %></span>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center justify-content-center">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">吊り元</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.hanging_origin_i18n %></span>
     </div>
     <p class='fw-bold mt-2 mb-2'>発注寸法</p>
     <div class="col-12 row g-0 data-list-2">
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
-        <span class='col-6 fw-bold'>W寸法</span>
-        <span class="col-6">
+      <div class="border-bottom row g-0 data-list d-flex align-items-center justify-content-center">
+        <span class='col-6 col-md-5 col-lg-4 fw-bold'>W寸法</span>
+        <span class="col-6 col-md-5 col-lg-4">
           <%= calc_order_size( inner_sash.width_up_size, 
                                inner_sash.width_middle_size,
                                inner_sash.width_down_size )%>
         </span>
       </div>
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
-        <span class="col-6 fw-bold">H寸法</span>
-        <span class="col-6">
+      <div class="border-bottom row g-0 data-list d-flex align-items-center justify-content-center">
+        <span class="col-6 col-md-5 col-lg-4 fw-bold">H寸法</span>
+        <span class="col-6 col-md-5 col-lg-4">
           <%= calc_order_size( inner_sash.height_left_size,
                               inner_sash.height_middle_size,
                               inner_sash.height_right_size )%>  
         </span>
       </div>
       <div class="row g-0 mt-4 mt-md-5 align-items-center">
-        <div class="col-3 mb-3">
+        <div class="col-3 mb-5">
           <% if @inner_sash.previous.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
               <i class="bi bi-arrow-left-circle-fill h1"></i>
             <% end %>
           <% end %>
         </div>
-        <div class="col-6 mb-3">
+        <div class="col-6 mb-5">
           <%= link_to '編集', inner_sashes_switch_path(template: 'edit_basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color col-11 col-lg-6' %>
         </div>
-        <div class="col-3 mb-3">
+        <div class="col-3 mb-5">
           <% if @inner_sash.next.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
               <i class="bi bi-arrow-right-circle-fill h1"></i>

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,14 +1,14 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: 'nav-link active',
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? opening)}",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: 'nav-link',
+    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? h_cross)}",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: 'nav-link', 
+    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? w_cross)}", 
         data: { turbo_stream: true } %>
   </li>
 </ul>

--- a/app/views/inner_sashes/_photo_and_others.html.erb
+++ b/app/views/inner_sashes/_photo_and_others.html.erb
@@ -1,38 +1,38 @@
 <%= turbo_frame_tag 'photo-and-others' do %>
   <div class='row text-center'>
-    <div class="col-12 row g-0 data-list align-items-center border-bottom">
-      <span class="col-6 fw-bold">平板</span>
-      <span class="col-6"><%= inner_sash.is_flat_bar ? "有" : "無" %></span>
+    <div class="col-12 row g-0 data-list align-items-center justify-content-center border-bottom">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">平板</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.is_flat_bar ? "有" : "無" %></span>
     </div>
-    <div class="col-12 row border-bottom g-0 data-list align-items-center">
-      <span class="col-6 fw-bold">アジャスト上枠</span>
-      <span class="col-6"><%= inner_sash.is_adjust ? "有" : "無" %></span>
+    <div class="col-12 row border-bottom g-0 data-list justify-content-center align-items-center">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">アジャスト上枠</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.is_adjust ? "有" : "無" %></span>
     </div>
-    <div class="col-12 row border-bottom g-0 data-list align-items-center">
-      <span class="col-6 fw-bold">備考</span>
-      <span class="col-6"><%= inner_sash.site_memo.remark %></span>
+    <div class="col-12 row border-bottom g-0 data-list justify-content-center align-items-center">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">備考</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.site_memo.remark %></span>
     </div>
     <p class='fw-bold mt-2 mb-2'>写真</p>
-    <div class="col-12 row g-0 data-list-2">
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
+    <div class="col-12 row g-0">
+      <div class="border-bottom row g-0 data-list d-flex align-items-center h-100">
         <% inner_sash.photos.each do |photo| %>
           <div class="col-3">
             <%= image_tag photo.file_name_url(:thumb) %>
           </div>
         <% end %>
       </div>
-      <div class="row g-0 mt-4 mt-md-5 align-items-center">
-        <div class="col-3 mb-3">
+      <div class="row g-0 mt-4 align-items-center">
+        <div class="col-3 mb-5">
           <% if @inner_sash.previous.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
               <i class="bi bi-arrow-left-circle-fill h1"></i>
             <% end %>
           <% end %>
         </div>
-        <div class="col-6 mb-3">
+        <div class="col-6 mb-5">
           <%= link_to '編集', inner_sashes_switch_path(template: 'edit_photo_and_others', id: inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color col-11 col-lg-6'%>
         </div>
-        <div class="col-3 mb-3">
+        <div class="col-3 mb-5">
           <% if @inner_sash.next.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
               <i class="bi bi-arrow-right-circle-fill h1"></i>

--- a/app/views/inner_sashes/_shoji_and_glass.html.erb
+++ b/app/views/inner_sashes/_shoji_and_glass.html.erb
@@ -1,43 +1,43 @@
 <%= turbo_frame_tag 'shoji-and-glass' do %>
   <div class='row text-center'>
-    <div class="col-12 row g-0 data-list align-items-center border-bottom">
-      <span class="col-6 fw-bold">中桟</span>
-      <span class="col-6"><%= inner_sash.middle_frame_height %></span>
+    <div class="col-12 row g-0 data-list align-items-center justify-content-center border-bottom">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">中桟</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.middle_frame_height %></span>
     </div>
-    <div class="col-12 row border-bottom g-0 data-list align-items-center">
-      <span class="col-6 fw-bold">クレセント</span>
-      <span class="col-6"><%= inner_sash.key_height %></span>
+    <div class="col-12 row border-bottom g-0 data-list align-items-center justify-content-center">
+      <span class="col-6 col-md-5 col-lg-4 fw-bold">クレセント</span>
+      <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.key_height %></span>
     </div>
     <p class='fw-bold mt-2 mb-2'>ガラス</p>
     <div class="col-12 row g-0 data-list-2">
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
-        <span class='col-6 fw-bold'>種類</span>
-        <span class="col-6"><%= inner_sash.glass_kind_i18n %></span>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center justify-content-center">
+        <span class='col-6 col-md-5 col-lg-4 fw-bold'>種類</span>
+        <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.glass_kind_i18n %></span>
       </div>
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
-        <span class="col-6 fw-bold">色</span>
-        <span class="col-6"><%= inner_sash.glass_color_i18n %></span>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center justify-content-center">
+        <span class="col-6 col-md-5 col-lg-4 fw-bold">色</span>
+        <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.glass_color_i18n %></span>
       </div>
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
-        <span class="col-6 fw-bold">単板・複層</span>
-        <span class="col-6"><%= inner_sash.glass_thickness_i18n %></span>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center justify-content-center">
+        <span class="col-6 col-md-5 col-lg-4 fw-bold">単板・複層</span>
+        <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.glass_thickness_i18n %></span>
       </div>
-      <div class="border-bottom row g-0 data-list d-flex align-items-center">
-        <span class="col-6 fw-bold">Low-E</span>
-        <span class="col-6"><%= inner_sash.is_low_e ? "有" : "無" %></span>
+      <div class="border-bottom row g-0 data-list d-flex align-items-center justify-content-center">
+        <span class="col-6 col-md-5 col-lg-4 fw-bold">Low-E</span>
+        <span class="col-6 col-md-5 col-lg-4"><%= inner_sash.is_low_e ? "有" : "無" %></span>
       </div>
       <div class="row g-0 mt-4 mt-md-5 align-items-center">
-        <div class="col-3 mb-3">
+        <div class="col-3 mb-5">
           <% if @inner_sash.previous.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
               <i class="bi bi-arrow-left-circle-fill h1"></i>
             <% end %>
           <% end %>
         </div>
-        <div class="col-6 mb-3">
+        <div class="col-6 mb-5">
           <%= link_to '編集', inner_sashes_switch_path(template: 'edit_shoji_and_glass', id: inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-primary bright-color col-11 col-lg-6' %>
         </div>
-        <div class="col-3 mb-3">
+        <div class="col-3 mb-5">
           <% if @inner_sash.next.present? %>
             <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
               <i class="bi bi-arrow-right-circle-fill h1"></i>

--- a/app/views/inner_sashes/_tabs.html.erb
+++ b/app/views/inner_sashes/_tabs.html.erb
@@ -1,23 +1,23 @@
 <ul class="nav nav-tabs nav-fill">
   <li class='nav-item'>
-    <%= link_to inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), class: 'nav-link active',
+    <%= link_to inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), class: "nav-link #{is_active(defined? basic)}",
         data: { turbo_stream: true } do %>
-      <p class="d-md-none">寸法</p>
-      <p class="d-none d-md-block">基本情報</p>
+      <p class="d-md-none m-0">寸法</p>
+      <p class="d-none d-md-block m-0">基本情報</p>
     <% end %>
   </li>
   <li class='nav-item'>
-    <%= link_to inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id), class: 'nav-link',
+    <%= link_to inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id), class: "nav-link #{is_active(defined? shoji)}",
         data: { turbo_stream: true } do %>
-      <p class="d-md-none">障子</p>
-      <p class="d-none d-md-block">障子・ガラス</p>
+      <p class="d-md-none m-0">障子</p>
+      <p class="d-none d-md-block m-0">障子・ガラス</p>
     <% end %>
   </li>
   <li class='nav-item'>
-    <%= link_to inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id), class: 'nav-link',
+    <%= link_to inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id), class: "nav-link #{is_active(defined? photo)}",
         data: { turbo_stream: true} do %>
-      <p class="d-md-none">写真</p>
-      <p class="d-none d-md-block">写真・その他</p>
+      <p class="d-md-none m-0">写真</p>
+      <p class="d-none d-md-block m-0">写真・その他</p>
     <% end %>    
   </li>
 </ul>

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -1,8 +1,4 @@
 <%= turbo_stream_flash %>
-<%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
-  <%= render 'drawing', inner_sash: @inner_sash %>
-<% end %>
 <%= turbo_stream.update 'inner-sash-data' do %>
   <%= render 'tabs', basic: 'active' %>
   <%= render 'basic_info', inner_sash: @inner_sash %>

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -1,5 +1,6 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'drawing' do %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
   <%= render 'drawing', inner_sash: @inner_sash %>
 <% end %>
 <%= turbo_stream.update 'inner-sash-data' do %>

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -4,6 +4,6 @@
   <%= render 'drawing', inner_sash: @inner_sash %>
 <% end %>
 <%= turbo_stream.update 'inner-sash-data' do %>
-  <%= render 'tabs' %>
+  <%= render 'tabs', basic: 'active' %>
   <%= render 'basic_info', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/edit_basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_basic_info.turbo_stream.erb
@@ -1,9 +1,11 @@
 <%= turbo_stream.update 'basic-info' do %>
-  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id) do |inner_sash| %>
-    <%= render 'basic_info_fields', inner_sash: inner_sash %>
-    <%= render 'size_fields', inner_sash: inner_sash%>
+  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id), class: 'row justify-content-center' do |inner_sash| %>
+    <div class="col-12 col-md-10 col-lg-7">
+      <%= render 'basic_info_fields', inner_sash: inner_sash %>
+      <%= render 'size_fields', inner_sash: inner_sash%>
+    </div>
     <%= inner_sash.hidden_field :template, value: 'basic_info'  %>
-    <div class="row justify-content-center p-3 mb-lg-5">
+    <div class="row justify-content-center p-3 mb-lg-2">
       <%= inner_sash.submit '保存', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
     </div>
   <% end %>

--- a/app/views/inner_sashes/edit_basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_basic_info.turbo_stream.erb
@@ -3,7 +3,11 @@
     <%= render 'basic_info_fields', inner_sash: inner_sash %>
     <%= render 'size_fields', inner_sash: inner_sash%>
     <%= inner_sash.hidden_field :template, value: 'basic_info'  %>
-    <%= inner_sash.submit '保存' %>
+    <div class="row justify-content-center p-3 mb-lg-5">
+      <%= inner_sash.submit '保存', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
+    </div>
   <% end %>
-  <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), data: {turbo_stream: true} %>
+  <div class="row justify-content-center p-3 mb-lg-5">
+    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-secondary col-9 col-md-4 col-lg-2' %>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/edit_photo_and_others.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_photo_and_others.turbo_stream.erb
@@ -1,14 +1,17 @@
 <%= turbo_stream.replace 'photo-and-others' do %>
-  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id) do |inner_sash| %>
-    <%= render 'accessorie_fields', inner_sash: inner_sash  %>
+  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id),  class: 'row justify-content-center' do |inner_sash| %>
+    <div class="col-12 col-md-10 col-lg-7">
+      <%= render 'accessorie_fields', inner_sash: inner_sash  %>
+    </div>
     <%= inner_sash.fields_for :photos do |photo| %>
       <%= render 'photo_fields', f: photo %>
     <% end %>
-    <div class="links">
-      <%= link_to_add_association "追加", inner_sash, :photos %>
-    </div>
     <%= inner_sash.hidden_field :template, value: 'photo_and_others'  %>
-    <%= inner_sash.submit '保存' %>
+    <div class="row justify-content-center p-3 mb-lg-2 mt-3">
+      <%= inner_sash.submit '保存', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
+    </div>
   <% end %>
-  <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'photo_and_others',id: @inner_sash.id), data: {turbo_stream: true} %>
+  <div class="row justify-content-center p-3 mb-lg-5">
+    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'photo_and_others',id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-secondary col-9 col-md-4 col-lg-2' %>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/edit_photo_and_others.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_photo_and_others.turbo_stream.erb
@@ -3,9 +3,6 @@
     <div class="col-12 col-md-10 col-lg-7">
       <%= render 'accessorie_fields', inner_sash: inner_sash  %>
     </div>
-    <%= inner_sash.fields_for :photos do |photo| %>
-      <%= render 'photo_fields', f: photo %>
-    <% end %>
     <%= inner_sash.hidden_field :template, value: 'photo_and_others'  %>
     <div class="row justify-content-center p-3 mb-lg-2 mt-3">
       <%= inner_sash.submit '保存', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>

--- a/app/views/inner_sashes/edit_shoji_and_glass.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_shoji_and_glass.turbo_stream.erb
@@ -1,8 +1,14 @@
 <%= turbo_stream.update 'shoji-and-glass' do %>
-  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id) do |inner_sash| %>
-    <%= render partial: 'shoji_and_glass_fields', locals: { inner_sash:  inner_sash } %>
+  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id), class: 'row justify-content-center' do |inner_sash| %>
+    <div class="col-12 col-md-10 col-lg-7">
+      <%= render partial: 'shoji_and_glass_fields', locals: { inner_sash:  inner_sash } %>
+    </div>
     <%= inner_sash.hidden_field :template, value: 'shoji_and_glass'  %>
-    <%= inner_sash.submit '保存' %>
+    <div class="row justify-content-center p-3 mb-lg-2">
+      <%= inner_sash.submit '保存', class: 'btn btn-primary col-9 col-md-4 col-lg-2' %>
+    </div>
   <% end %>
-  <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'shoji_and_glass',id: @inner_sash.id), data: {turbo_stream: true} %>
+  <div class="row justify-content-center p-3 mb-lg-5">
+    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'shoji_and_glass',id: @inner_sash.id), data: {turbo_stream: true}, class: 'btn btn-secondary col-9 col-md-4 col-lg-2' %>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash, h_cross: 'active' %>
   <div class="position-relative">
     <%= image_tag 'h_cross_section', class: 'img-fluid' %>
     <p class="width-frame-depth"><%= @inner_sash.width_frame_depth %></p>

--- a/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.update 'drawing' do %>
   <%= render 'drawing_tabs', inner_sash: @inner_sash, h_cross: 'active' %>
   <div class="position-relative">
-    <%= image_tag 'h_cross_section', class: 'img-fluid' %>
-    <p class="width-frame-depth"><%= @inner_sash.width_frame_depth %></p>
+    <%= image_tag 'h_cross_section', class: 'cross-image' %>
+    <p class="width-size"><%= @inner_sash.width_frame_depth %></p>
   </div>
 <% end %>

--- a/app/views/inner_sashes/opening_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/opening_drawing.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active' } %>
   <%= render 'drawing', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/photo_and_others.turbo_stream.erb
+++ b/app/views/inner_sashes/photo_and_others.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'inner-sash-data' do %>
-  <%= render 'tabs' %>
+  <%= render 'tabs', photo: 'active' %>
   <%= render 'photo_and_others', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/shoji_and_glass.turbo_stream.erb
+++ b/app/views/inner_sashes/shoji_and_glass.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'inner-sash-data' do %>
-  <%= render 'tabs' %>  
+  <%= render 'tabs', shoji: 'active' %>  
   <%= render 'shoji_and_glass', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,5 +1,5 @@
 <section id="mobile">
-  <%= render 'site_label' %>
+  <%= render 'site_label', parent: @inner_sash.site_memo.site  %>
   <div class="container" style='margin-top:88px;'>
     <div class="row d-sm-none">
       <div class="col <%= @inner_sash.order %>-label p-1 mb-2">

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -51,11 +51,11 @@
     </div>
     <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
       <%= turbo_frame_tag 'drawing' do %>
-        <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+        <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active'} %>
         <%= render 'drawing', inner_sash: @inner_sash %>
       <% end %>
-      <div id="inner-sash-data" class='mb-3'>
-        <%= render 'tabs' %>
+      <div id="inner-sash-data">
+        <%= render 'tabs', basic: 'active' %>
         <%= render 'basic_info', inner_sash: @inner_sash%>
       </div>
     <% end %>

--- a/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream.update 'drawing' do %>
   <%= render 'drawing_tabs', inner_sash: @inner_sash, w_cross: 'active' %>
   <div class="position-relative">
-    <%= image_tag 'w_cross_section', class: 'img-fluid'%>
-    <p class='height-frame-depth'><%= @inner_sash.height_frame_depth %></p>
+    <%= image_tag 'w_cross_section', class: 'cross-image'%>
+    <p class='height-size'><%= @inner_sash.height_frame_depth %></p>
   </div>
 <% end %>

--- a/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash, w_cross: 'active' %>
   <div class="position-relative">
     <%= image_tag 'w_cross_section', class: 'img-fluid'%>
     <p class='height-frame-depth'><%= @inner_sash.height_frame_depth %></p>


### PR DESCRIPTION
## 概要
現場メモ詳細ページのUIの調整を行った。要素の幅の調整や、画像のサイズの調整などを行った。

## やったこと
- データの詳細の各項目の幅調整
- タブ切り替え時にactive付与
- 画像の最大サイズの設定

## やってないこと
- タブ切り替えをjsを使って実装（現段階はとりあえずで、今後jsで実装する予定）

## 課題・疑問点
- 今回のタブ切り替えはセオリーから外れた実装になっていると思うが、jsを使ってやった方がいいのかどうか？

