### PR TITLE
現場詳細ページの開口図の修正

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -31,6 +31,11 @@
   background-color: var(--thin-sub) !important;
 }
 
+.drawing{
+  max-width: 800px;
+}
+
+
 .cross-image{
   display: block;
   margin: auto;

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -1,7 +1,7 @@
 class InnerSashesController < ApplicationController
   before_action :set_site_memo, only: [:new_step2, :new_step3, :new_step4, :new_step5,
-                                       :new_append_shoji_and_glass, :new_append_photo_and_others,
-                                       :new_append_basic_info, :new_comfirmation]
+                                       :new_append_room, :new_append_shoji_and_glass, 
+                                       :new_append_photo_and_others, :new_append_basic_info, :new_comfirmation]
 
   def new_step2
     load_inner_sashes
@@ -10,7 +10,7 @@ class InnerSashesController < ApplicationController
   end
 
   def new_append_room
-    @inner_sash = InnerSash.new(inner_sash_params)
+    @inner_sash = InnerSash.new(inner_sash_params.merge(site_memo_id: @site_memo.id))
     @inner_sash = InnerSash.new if @inner_sash.save
     load_inner_sashes
   end
@@ -80,8 +80,9 @@ class InnerSashesController < ApplicationController
   def switch(template:, id:)
     @inner_sash = InnerSash.find(id)
      # templateはbasic_info、shoji_and_glass、photo_and_others
-     # opening_drawing h_cross_drawing w_cross_drawing　のどれか
-    render "#{template}", content_type: 'text/vnd.turbo-stream.html'
+     # h_cross_drawing w_cross_drawing　のどれか
+    # render "#{template}", content_type: 'text/vnd.turbo-stream.html'
+    render "#{template}"
   end
 
   def update(id:)
@@ -101,7 +102,7 @@ private
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,
                                       :sash_type, :color, :number_of_shoji, :hanging_origin, :is_flat_bar, :is_adjust, 
                                       :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height,
-                                      :template, photos_attributes: [:id, :file_name, :_destroy]).merge(site_memo_id: set_site_memo.id)
+                                      :template, photos_attributes: [:id, :file_name, :_destroy])
   end
 
   def site_memo_params

--- a/app/javascript/draw_opening.js
+++ b/app/javascript/draw_opening.js
@@ -1,7 +1,80 @@
-var openingCanvas = document.getElementById('opening');
-var wLineCanvas = document.getElementById('w-center-line')
-var hLineCanvas = document.getElementById('h-center-line')
-var openingCtx = openingCanvas.getContext("2d")
-var wLineCtx = wLineCanvas.getContext("2d")
-var hLineCtx = hLineCanvas.getContext("2d")
-openingCtx.strokeRect(100,100,300,200)
+document.addEventListener("turbo:load", function() {
+  let openingCanvas = document.getElementById('opening');
+  let openingCtx = openingCanvas.getContext("2d")
+
+  //横寸法
+  let widthUp = document.getElementById('width-up')
+  let widthMiddle = document.getElementById('width-middle')
+  let widthDown = document.getElementById('width-down')
+
+  //縦寸法
+  let heightLeft = document.getElementById('height-left')
+  let heightMiddle = document.getElementById('height-middle')
+  let heightRight = document.getElementById('height-right')
+
+  const startZero = 0
+  const startX = 100
+  const startY = 150
+  const sizeX = 300
+  const sizeY = 350
+  const sizeBoxLong = 80
+  const sizeBoxShort = 50
+  const varticalCenter = sizeY/2 + startY
+  const horizontalCenter = sizeX/2 +startX
+  const horizontalOneThiird = sizeX/3 + startX; //3分の1の位置
+  const goalX = startX + sizeX
+  const goalY = startY + sizeY
+  const arrowSize = 10
+  const fontSize = 30
+  const boxMargin = 10
+
+  // 縦横中央寸法の四角い枠用
+  const widthBoxX = horizontalCenter
+  const widthBoxY = varticalCenter - boxMargin * 5
+  const heightBoxX = horizontalOneThiird + boxMargin
+  const heightBoxY = varticalCenter + boxMargin * 5
+
+  drawOpening()
+
+  function drawOpening(){
+    //開口図のベースとなる四角形
+    openingCtx.strokeRect(startX, startY, sizeX, sizeY)
+
+    //横戦と矢印
+    openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
+    openingCtx.lineTo(startX+arrowSize, varticalCenter+arrowSize) //左辺矢印の下側
+    openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
+    openingCtx.lineTo(startX+arrowSize, varticalCenter-arrowSize) //左辺矢印の上側
+    openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
+    openingCtx.lineTo(goalX,varticalCenter)  //右辺の真ん中まで線を引く
+    openingCtx.lineTo(goalX-arrowSize,varticalCenter+arrowSize) //右辺矢印下側
+    openingCtx.moveTo(goalX, varticalCenter) //左辺の真ん中の点に移動
+    openingCtx.lineTo(goalX-arrowSize, varticalCenter-arrowSize) //右辺矢印上側
+
+    //縦線と矢印
+    openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
+    openingCtx.lineTo(horizontalOneThiird+arrowSize, startY+arrowSize) // 右側の矢印
+    openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
+    openingCtx.lineTo(horizontalOneThiird-arrowSize, startY+arrowSize) // 左側の矢印
+    openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
+    openingCtx.lineTo(horizontalOneThiird, goalY) // 下辺３分の1まで線を引く
+    openingCtx.lineTo(horizontalOneThiird+arrowSize, goalY-arrowSize) // 右側の矢印
+    openingCtx.moveTo(horizontalOneThiird, goalY) //上辺3分の１の位置に移動
+    openingCtx.lineTo(horizontalOneThiird-arrowSize, goalY-arrowSize) //左側の矢印
+
+    //中央サイズの枠
+    openingCtx.strokeRect(widthBoxX, widthBoxY - boxMargin, sizeBoxLong, sizeBoxShort) //横中央のサイズ入れる枠
+    openingCtx.strokeRect(heightBoxX, heightBoxY, sizeBoxLong, sizeBoxShort) //縦中央のサイズ入れる枠
+
+    openingCtx.stroke()
+
+    //図に寸法記入
+    openingCtx.font = `${fontSize}px serif`;
+    openingCtx.fillText(widthUp.textContent, horizontalOneThiird, startY - fontSize * 0.8) // 横上寸法表示
+    openingCtx.fillText(widthDown.textContent, horizontalOneThiird, startY + sizeY + fontSize * 1.5) //横下寸法表示
+    openingCtx.fillText(heightLeft.textContent, startZero, varticalCenter) // 左縦寸法表示
+    openingCtx.fillText(heightRight.textContent, startX + sizeX - fontSize, varticalCenter) // 縦右寸法表示
+    openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize, widthBoxY + fontSize) // 横中央寸法表示
+    openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize, heightBoxY + fontSize) //縦中央駿府表示
+  }
+});

--- a/app/javascript/draw_opening.js
+++ b/app/javascript/draw_opening.js
@@ -1,6 +1,20 @@
-document.addEventListener("turbo:load", function() {
+document.addEventListener("turbo:load", function(){
+  drawOpening()
+});
+
+//　turbo-streamの実行時に描画を更新する
+$(document).on('turbo:before-stream-render',function(){
+  setInterval(function(){
+    drawOpening()
+  },100)
+})
+
+
+function drawOpening(){
   let openingCanvas = document.getElementById('opening');
+  if (!openingCanvas) return;
   let openingCtx = openingCanvas.getContext("2d")
+  openingCtx.clearRect(0, 0, 500, 500);  //turbo-stream用に残っている描画を削除
 
   //横寸法
   let widthUp = document.getElementById('width-up')
@@ -34,47 +48,43 @@ document.addEventListener("turbo:load", function() {
   const heightBoxX = horizontalOneThiird + boxMargin
   const heightBoxY = varticalCenter + boxMargin * 5
 
-  drawOpening()
+  //開口図のベースとなる四角形
+  openingCtx.strokeRect(startX, startY, sizeX, sizeY)
 
-  function drawOpening(){
-    //開口図のベースとなる四角形
-    openingCtx.strokeRect(startX, startY, sizeX, sizeY)
+  //横戦と矢印
+  openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
+  openingCtx.lineTo(startX+arrowSize, varticalCenter+arrowSize) //左辺矢印の下側
+  openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
+  openingCtx.lineTo(startX+arrowSize, varticalCenter-arrowSize) //左辺矢印の上側
+  openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
+  openingCtx.lineTo(goalX,varticalCenter)  //右辺の真ん中まで線を引く
+  openingCtx.lineTo(goalX-arrowSize,varticalCenter+arrowSize) //右辺矢印下側
+  openingCtx.moveTo(goalX, varticalCenter) //左辺の真ん中の点に移動
+  openingCtx.lineTo(goalX-arrowSize, varticalCenter-arrowSize) //右辺矢印上側
 
-    //横戦と矢印
-    openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
-    openingCtx.lineTo(startX+arrowSize, varticalCenter+arrowSize) //左辺矢印の下側
-    openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
-    openingCtx.lineTo(startX+arrowSize, varticalCenter-arrowSize) //左辺矢印の上側
-    openingCtx.moveTo(startX, varticalCenter) //左辺の真ん中の点に移動
-    openingCtx.lineTo(goalX,varticalCenter)  //右辺の真ん中まで線を引く
-    openingCtx.lineTo(goalX-arrowSize,varticalCenter+arrowSize) //右辺矢印下側
-    openingCtx.moveTo(goalX, varticalCenter) //左辺の真ん中の点に移動
-    openingCtx.lineTo(goalX-arrowSize, varticalCenter-arrowSize) //右辺矢印上側
+  //縦線と矢印
+  openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
+  openingCtx.lineTo(horizontalOneThiird+arrowSize, startY+arrowSize) // 右側の矢印
+  openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
+  openingCtx.lineTo(horizontalOneThiird-arrowSize, startY+arrowSize) // 左側の矢印
+  openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
+  openingCtx.lineTo(horizontalOneThiird, goalY) // 下辺３分の1まで線を引く
+  openingCtx.lineTo(horizontalOneThiird+arrowSize, goalY-arrowSize) // 右側の矢印
+  openingCtx.moveTo(horizontalOneThiird, goalY) //上辺3分の１の位置に移動
+  openingCtx.lineTo(horizontalOneThiird-arrowSize, goalY-arrowSize) //左側の矢印
 
-    //縦線と矢印
-    openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
-    openingCtx.lineTo(horizontalOneThiird+arrowSize, startY+arrowSize) // 右側の矢印
-    openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
-    openingCtx.lineTo(horizontalOneThiird-arrowSize, startY+arrowSize) // 左側の矢印
-    openingCtx.moveTo(horizontalOneThiird, startY) //上辺3分の１の位置に移動
-    openingCtx.lineTo(horizontalOneThiird, goalY) // 下辺３分の1まで線を引く
-    openingCtx.lineTo(horizontalOneThiird+arrowSize, goalY-arrowSize) // 右側の矢印
-    openingCtx.moveTo(horizontalOneThiird, goalY) //上辺3分の１の位置に移動
-    openingCtx.lineTo(horizontalOneThiird-arrowSize, goalY-arrowSize) //左側の矢印
+  //中央サイズの枠
+  openingCtx.strokeRect(widthBoxX, widthBoxY - boxMargin, sizeBoxLong, sizeBoxShort) //横中央のサイズ入れる枠
+  openingCtx.strokeRect(heightBoxX, heightBoxY, sizeBoxLong, sizeBoxShort) //縦中央のサイズ入れる枠
 
-    //中央サイズの枠
-    openingCtx.strokeRect(widthBoxX, widthBoxY - boxMargin, sizeBoxLong, sizeBoxShort) //横中央のサイズ入れる枠
-    openingCtx.strokeRect(heightBoxX, heightBoxY, sizeBoxLong, sizeBoxShort) //縦中央のサイズ入れる枠
+  openingCtx.stroke()
 
-    openingCtx.stroke()
-
-    //図に寸法記入
-    openingCtx.font = `${fontSize}px serif`;
-    openingCtx.fillText(widthUp.textContent, horizontalOneThiird, startY - fontSize * 0.8) // 横上寸法表示
-    openingCtx.fillText(widthDown.textContent, horizontalOneThiird, startY + sizeY + fontSize * 1.5) //横下寸法表示
-    openingCtx.fillText(heightLeft.textContent, startZero, varticalCenter) // 左縦寸法表示
-    openingCtx.fillText(heightRight.textContent, startX + sizeX - fontSize, varticalCenter) // 縦右寸法表示
-    openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize, widthBoxY + fontSize) // 横中央寸法表示
-    openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize, heightBoxY + fontSize) //縦中央駿府表示
-  }
-});
+  //図に寸法記入
+  openingCtx.font = `${fontSize}px serif`;
+  openingCtx.fillText(widthUp.textContent, horizontalOneThiird, startY - fontSize * 0.8) // 横上寸法表示
+  openingCtx.fillText(widthDown.textContent, horizontalOneThiird, startY + sizeY + fontSize * 1.5) //横下寸法表示
+  openingCtx.fillText(heightLeft.textContent, startZero, varticalCenter) // 左縦寸法表示
+  openingCtx.fillText(heightRight.textContent, startX + sizeX - fontSize, varticalCenter) // 縦右寸法表示
+  openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize, widthBoxY + fontSize) // 横中央寸法表示
+  openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize, heightBoxY + fontSize) //縦中央駿府表示
+}

--- a/app/javascript/draw_opening.js
+++ b/app/javascript/draw_opening.js
@@ -83,8 +83,8 @@ function drawOpening(){
   openingCtx.font = `${fontSize}px serif`;
   openingCtx.fillText(widthUp.textContent, horizontalOneThiird, startY - fontSize * 0.8) // 横上寸法表示
   openingCtx.fillText(widthDown.textContent, horizontalOneThiird, startY + sizeY + fontSize * 1.5) //横下寸法表示
-  openingCtx.fillText(heightLeft.textContent, startZero, varticalCenter) // 左縦寸法表示
+  openingCtx.fillText(heightLeft.textContent, startZero - fontSize, varticalCenter) // 左縦寸法表示
   openingCtx.fillText(heightRight.textContent, startX + sizeX - fontSize, varticalCenter) // 縦右寸法表示
-  openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize, widthBoxY + fontSize) // 横中央寸法表示
-  openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize, heightBoxY + fontSize) //縦中央駿府表示
+  openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize*1.5, widthBoxY + fontSize) // 横中央寸法表示
+  openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize*1.5, heightBoxY + fontSize) //縦中央駿府表示
 }

--- a/app/views/inner_sashes/_drawing.html.erb
+++ b/app/views/inner_sashes/_drawing.html.erb
@@ -1,16 +1,31 @@
 <!--最終的にはcssでサイズ指定-->
-<canvas id="opening"></canvas>
-<%# <canvas id="w-center-line"></canvas>
-<canvas id='h-center-line'></canvas> %>
+<div class="col-12 row justify-content-center drawing">
+  <div class='col-12 col-md-8 col-lg-7'>
+    <canvas id="opening" width='500px' height='550px'></canvas>
+  </div>
+</div>
 
-<!-- w寸法 -->
-<%= inner_sash.width_up_size %>
-<%= inner_sash.width_middle_size %>
-<%= inner_sash.width_down_size %>
-                   
-
-<!-- h寸法 -->
-<%= inner_sash.height_left_size %>
-<%= inner_sash.height_middle_size %>
-<%= inner_sash.height_right_size %>
+<div class="d-none">
+  <!-- w寸法 -->
+  <div id="width-up"> 
+    <%= inner_sash.width_up_size %>
+  </div>
+  <div id="width-middle">
+    <%= inner_sash.width_middle_size %>
+  </div>
+  <div id="width-down">
+    <%= inner_sash.width_down_size %>
+  </div>
+                    
+  <!-- h寸法 -->
+  <div id="height-left">
+    <%= inner_sash.height_left_size %>
+  </div>
+  <div id="height-middle">
+    <%= inner_sash.height_middle_size %>
+  </div>
+  <div id="height-right">
+    <%= inner_sash.height_right_size %>
+  </div>
+</div>
 

--- a/app/views/inner_sashes/_drawing.html.erb
+++ b/app/views/inner_sashes/_drawing.html.erb
@@ -1,10 +1,3 @@
-<!--最終的にはcssでサイズ指定-->
-<div class="col-12 row justify-content-center drawing">
-  <div class='col-12 col-md-8 col-lg-7'>
-    <canvas id="opening" width='500px' height='550px'></canvas>
-  </div>
-</div>
-
 <div class="d-none">
   <!-- w寸法 -->
   <div id="width-up"> 
@@ -28,4 +21,9 @@
     <%= inner_sash.height_right_size %>
   </div>
 </div>
-
+<!--最終的にはcssでサイズ指定-->
+<div class="col-12 row justify-content-center drawing">
+  <div class='col-12 col-md-8 col-lg-7'>
+    <canvas id="opening" width='500px' height='550px'></canvas>
+  </div>
+</div>

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? opening)}",
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), id: 'opening-tab', class: "nav-link #{is_active(defined? opening)}",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -1,4 +1,10 @@
 <%= turbo_stream_flash %>
+<%= turbo_stream.update 'drawing' do %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <div class="row justify-content-center" style='height:350px;'>
+    <%= render 'drawing', inner_sash: @inner_sash %>
+  </div>
+<% end %>
 <%= turbo_stream.update 'inner-sash-data' do %>
   <%= render 'tabs', basic: 'active' %>
   <%= render 'basic_info', inner_sash: @inner_sash %>

--- a/app/views/inner_sashes/opening_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/opening_drawing.turbo_stream.erb
@@ -1,4 +1,6 @@
 <%= turbo_stream.update 'drawing' do %>
   <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active' } %>
-  <%= render 'drawing', inner_sash: @inner_sash %>
+  <div class="row justify-content-center" style='height:350px;'>
+    <%= render 'drawing', inner_sash: @inner_sash %>
+  </div>
 <% end %>

--- a/app/views/inner_sashes/room_append.js.erb
+++ b/app/views/inner_sashes/room_append.js.erb
@@ -1,2 +1,0 @@
-$('.size-info').append("<li><%= @inner_sash["room"] %></li>")
-$('#size-form')[0].reset()

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -56,10 +56,10 @@
           <%= render 'drawing', inner_sash: @inner_sash %>
         </div>
       <% end %>
-      <div id="inner-sash-data">
+      <%= turbo_frame_tag 'inner-sash-data' do %>
         <%= render 'tabs', basic: 'active' %>
         <%= render 'basic_info', inner_sash: @inner_sash%>
-      </div>
+      <% end %>
     <% end %>
   </div>
 </section>
@@ -67,5 +67,5 @@
 <%= stylesheet_link_tag "show", "data-turbo-track": "reload" %>
 
 <% content_for :js do %>
-  <%= javascript_import_module_tag "draw_opening" %>
-<% end %>
+    <%= javascript_import_module_tag "draw_opening" %>
+  <% end %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,6 +1,6 @@
 <section id="mobile">
   <%= render 'site_label', parent: @inner_sash.site_memo.site  %>
-  <div class="container" style='margin-top:88px;'>
+    <div class="container" style='margin-top:88px;'>
     <div class="row d-sm-none">
       <div class="col <%= @inner_sash.order %>-label p-1 mb-2">
         <%= turbo_frame_tag 'order' do %>
@@ -52,7 +52,9 @@
     <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
       <%= turbo_frame_tag 'drawing' do %>
         <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active'} %>
-        <%= render 'drawing', inner_sash: @inner_sash %>
+        <div class="row justify-content-center" style='height:350px;'>
+          <%= render 'drawing', inner_sash: @inner_sash %>
+        </div>
       <% end %>
       <div id="inner-sash-data">
         <%= render 'tabs', basic: 'active' %>
@@ -62,8 +64,8 @@
   </div>
 </section>
 
+<%= stylesheet_link_tag "show", "data-turbo-track": "reload" %>
+
 <% content_for :js do %>
   <%= javascript_import_module_tag "draw_opening" %>
 <% end %>
-
-<%= stylesheet_link_tag "show", "data-turbo-track": "reload" %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -33,7 +33,7 @@
           <% end %>
         </li>
         <li>
-          <p id="inner-sash-delete" class='dropdown-item m-0'>
+          <p class='dropdown-item m-0'>
             <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
           </p>
         </li>
@@ -44,7 +44,7 @@
         <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
       <% end %>
     </div>
-    <div id="inner-sash-delete-pc" class="col d-none d-lg-block">
+    <div class="col d-none d-lg-block">
         <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'btn btn-danger px-4 py-0'%>
     </div>
   </div>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -1,68 +1,66 @@
-<section id="mobile">
-  <%= render 'site_label', parent: @inner_sash.site_memo.site  %>
-    <div class="container" style='margin-top:88px;'>
-    <div class="row d-sm-none">
-      <div class="col <%= @inner_sash.order %>-label p-1 mb-2">
-        <%= turbo_frame_tag 'order' do %>
-          <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
-        <% end %>
-      </div>
-    </div>
-    <div class="row align-items-center text-center mb-3" style='height:60px;'>
-      <div class="col">
-        <p class='m-0'><%= @inner_sash.room %></p>
-      </div>
-      <div class="col">
-        <p class='m-0'>内窓</p>
-      </div>
-      <div class="col-2 d-none d-sm-block">
-        <%= turbo_frame_tag 'order', class: "badge #{@inner_sash.order}-label py-1 px-3" do %>
-          <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
-        <% end %>
-      </div>
-      <div class="col">
-        <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
-      </div>
-      <div class="col-1 p-0 dropdown d-lg-none">
-        <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-          <i class="bi bi-three-dots-vertical h1"></i>
-        </a>
-        <ul class="dropdown-menu mt-2">
-          <li>
-            <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
-              <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
-            <% end %>
-          </li>
-          <li>
-            <p id="inner-sash-delete" class='dropdown-item m-0'>
-              <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
-            </p>
-          </li>
-        </ul>
-      </div>
-      <div class="col d-none d-lg-block">
-        <%= turbo_frame_tag 'order-link'  do %>
-          <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
-        <% end %>
-      </div>
-      <div id="inner-sash-delete" class="col d-none d-lg-block">
-         <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'btn btn-danger px-4 py-0'%>
-      </div>
-    </div>
-    <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
-      <%= turbo_frame_tag 'drawing' do %>
-        <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active'} %>
-        <div class="row justify-content-center" style='height:350px;'>
-          <%= render 'drawing', inner_sash: @inner_sash %>
-        </div>
+<%= render 'site_label', parent: @inner_sash.site_memo.site  %>
+  <div class="container" style='margin-top:88px;'>
+  <div class="row d-sm-none">
+    <div class="col <%= @inner_sash.order %>-label p-1 mb-2">
+      <%= turbo_frame_tag 'order' do %>
+        <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
       <% end %>
-      <%= turbo_frame_tag 'inner-sash-data' do %>
-        <%= render 'tabs', basic: 'active' %>
-        <%= render 'basic_info', inner_sash: @inner_sash%>
-      <% end %>
-    <% end %>
+    </div>
   </div>
-</section>
+  <div class="row align-items-center text-center mb-3" style='height:60px;'>
+    <div class="col">
+      <p class='m-0'><%= @inner_sash.room %></p>
+    </div>
+    <div class="col">
+      <p class='m-0'>内窓</p>
+    </div>
+    <div class="col-2 d-none d-sm-block">
+      <%= turbo_frame_tag 'order-pc', class: "badge #{@inner_sash.order}-label py-1 px-3" do %>
+        <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+      <% end %>
+    </div>
+    <div class="col">
+      <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
+    </div>
+    <div class="col-1 p-0 dropdown d-lg-none">
+      <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="bi bi-three-dots-vertical h1"></i>
+      </a>
+      <ul class="dropdown-menu mt-2">
+        <li>
+          <%= turbo_frame_tag 'order-link', class: 'dropdown-item'  do %>
+            <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+          <% end %>
+        </li>
+        <li>
+          <p id="inner-sash-delete" class='dropdown-item m-0'>
+            <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div class="col d-none d-lg-block">
+      <%= turbo_frame_tag 'order-link-pc' do %>
+        <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+      <% end %>
+    </div>
+    <div id="inner-sash-delete-pc" class="col d-none d-lg-block">
+        <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'btn btn-danger px-4 py-0'%>
+    </div>
+  </div>
+  <%= turbo_frame_tag 'inner-sash-data-wrap' do %>
+    <%= turbo_frame_tag 'drawing' do %>
+      <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active'} %>
+      <div class="row justify-content-center" style='height:350px;'>
+        <%= render 'drawing', inner_sash: @inner_sash %>
+      </div>
+    <% end %>
+    <%= turbo_frame_tag 'inner-sash-data' do %>
+      <%= render 'tabs', basic: 'active' %>
+      <%= render 'basic_info', inner_sash: @inner_sash%>
+    <% end %>
+  <% end %>
+</div>
 
 <%= stylesheet_link_tag "show", "data-turbo-track": "reload" %>
 

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -15,8 +15,10 @@
       <p class='m-0'>内窓</p>
     </div>
     <div class="col-2 d-none d-sm-block">
-      <%= turbo_frame_tag 'order-pc', class: "badge #{@inner_sash.order}-label py-1 px-3" do %>
-        <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+      <%= turbo_frame_tag 'order-pc' do %>
+        <div class="badge <%= @inner_sash.order %>-label py-1 px-3">
+          <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+        </div>
       <% end %>
     </div>
     <div class="col">

--- a/app/views/inner_sashes/update_order.turbo_stream.erb
+++ b/app/views/inner_sashes/update_order.turbo_stream.erb
@@ -1,4 +1,10 @@
 <%= turbo_stream_flash %>
+<%= turbo_stream.update 'order-pc' do %>
+  <%= @inner_sash.order_i18n %>
+<% end %>
+<%= turbo_stream.update "order-link-pc" do %>
+  <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
+<% end %>
 <%= turbo_stream.update 'order' do %>
   <%= @inner_sash.order_i18n %>
 <% end %>

--- a/app/views/inner_sashes/update_order.turbo_stream.erb
+++ b/app/views/inner_sashes/update_order.turbo_stream.erb
@@ -1,12 +1,14 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'order-pc' do %>
-  <%= @inner_sash.order_i18n %>
+  <div class="badge <%= @inner_sash.order %>-label py-1 px-3">
+    <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
+  </div>
 <% end %>
 <%= turbo_stream.update "order-link-pc" do %>
   <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
 <% end %>
 <%= turbo_stream.update 'order' do %>
-  <%= @inner_sash.order_i18n %>
+  <p class='bright-color m-0'><%= @inner_sash.order_i18n %></p>
 <% end %>
 <%= turbo_stream.update "order-link" do %>
   <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>


### PR DESCRIPTION
## 概要
現場メモ詳細ページに表示する開口図を一応表示はしていたが、全然使えるものではなかったので修正
その際に気づいたちょっとしたバグの修正とリファクタリングを行った。

## やったこと
- canvasを使って開口図を描画
- turbo-streamが発生した時の開口図の再描画
- 発注切り替えの際のturbo-streamの修正
- 現場メモのデータ更新できないバグ修正

## やってないこと
- htmlが冗長になっており、それに伴ってturbo-streamも冗長になっているのでそれの修正

## 課題・疑問点

