### PR TITLE
現場詳細ページ図面周りの修正

### DIFF
--- a/app/javascript/draw_opening.js
+++ b/app/javascript/draw_opening.js
@@ -31,8 +31,6 @@ function drawOpening(){
   const startY = 150
   const sizeX = 300
   const sizeY = 350
-  const sizeBoxLong = 80
-  const sizeBoxShort = 50
   const varticalCenter = sizeY/2 + startY
   const horizontalCenter = sizeX/2 +startX
   const horizontalOneThiird = sizeX/3 + startX; //3分の1の位置
@@ -47,6 +45,8 @@ function drawOpening(){
   const widthBoxY = varticalCenter - boxMargin * 5
   const heightBoxX = horizontalOneThiird + boxMargin
   const heightBoxY = varticalCenter + boxMargin * 5
+  const sizeBoxLong = 90
+  const sizeBoxShort = 50
 
   //開口図のベースとなる四角形
   openingCtx.strokeRect(startX, startY, sizeX, sizeY)
@@ -85,6 +85,6 @@ function drawOpening(){
   openingCtx.fillText(widthDown.textContent, horizontalOneThiird, startY + sizeY + fontSize * 1.5) //横下寸法表示
   openingCtx.fillText(heightLeft.textContent, startZero - fontSize, varticalCenter) // 左縦寸法表示
   openingCtx.fillText(heightRight.textContent, startX + sizeX - fontSize, varticalCenter) // 縦右寸法表示
-  openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize*1.5, widthBoxY + fontSize) // 横中央寸法表示
-  openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize*1.5, heightBoxY + fontSize) //縦中央駿府表示
+  openingCtx.fillText(widthMiddle.textContent, widthBoxX - fontSize, widthBoxY + fontSize) // 横中央寸法表示
+  openingCtx.fillText(heightMiddle.textContent,heightBoxX - fontSize, heightBoxY + fontSize) //縦中央駿府表示
 }

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), id: 'opening-tab', class: "nav-link #{is_active(defined? opening)}",
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? opening)}",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
+  <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active'} %>
   <div class="row justify-content-center" style='height:350px;'>
     <%= render 'drawing', inner_sash: @inner_sash %>
   </div>


### PR DESCRIPTION
## 概要
スマホの実機で確認してみたところ、図面の寸法表示位置がずれていたので修正。
内窓寸法データにタブを切り替えた際、図面切り替えタブがactive状態にならないバグ修正

## やったこと
- draw_opening.jsの寸法表示位置の値修正
- 内窓データタブ切り替えのturbo-streamで、図面切り替えタブがactive状態になるように設定

## やってないこと

## 課題・疑問点

