### PR TITLE
[hot-fix]本番環境でcocoonが動かないバグ修正

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,6 +16,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 Rails.application.config.assets.precompile += %w( 
   bootstrap.min.js 
   popper.js 
+  cocoon.js
   top.css
   index.css
   show.css


### PR DESCRIPTION
## 概要
本番環境でcocoonが動かなかった。assetsにcocoon.jsが入っておらず、プリコンパイルされていないのが原因？
 assets.rbでcocoon.jsを追加し、ローカルでプリコンパイルを試してところ無事できた

## やったこと
- assets.rbにcocoon.jsを追加

## やってないこと

## 課題・疑問点

