### PR TITLE
bootstrapのドロップダウンが使えないバグ修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "jquery"
-import "./cocoon"
-import '@popperjs/core'
 import "bootstrap"
+import "./cocoon"
 import "@hotwired/turbo-rails"
 import "controllers"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,5 +9,6 @@ pin "draw_opening"
 pin "suggest_contractor"
 pin "jquery", to: "https://code.jquery.com/jquery-3.7.1.min.js"
 pin "@nathanvda/cocoon"
-pin "bootstrap" # @5.3.3
-pin "@popperjs/core", to: "https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.11.8/umd/popper.min.js" # @2.11.8
+# pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js", preload: true     # @2.11.8
+pin "bootstrap", to: "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" # @5.3.3
+# pin "@popperjs/core", to: "https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.11.8/umd/popper.min.js" # @2.11.8

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,8 +14,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w( 
-  bootstrap.min.js 
-  popper.js 
+  bootstrap.min.js
   cocoon.js
   top.css
   index.css


### PR DESCRIPTION
## 概要
bootstrapのドロップダウンが使えない状態だったので修正

## やったこと
- bootstrapのcdnリンク変更
- popper.jsなくても使える状態に

## やってないこと

## 課題・疑問点
