### PR TITLE
bootstrapのドロップダウンが動かないバグ修正2

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -26,7 +26,7 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  position: relative; 
+  position: relative;
   z-index: 0;
 }
 

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -26,7 +26,7 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  position: relative;
+  position: relative; 
   z-index: 0;
 }
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "jquery"
 import "bootstrap"
-import "./cocoon"
 import "@hotwired/turbo-rails"
 import "controllers"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,7 +8,7 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "draw_opening"
 pin "suggest_contractor"
 pin "jquery", to: "https://code.jquery.com/jquery-3.7.1.min.js"
-pin "@nathanvda/cocoon"
+# pin "@nathanvda/cocoon"
 # pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js", preload: true     # @2.11.8
 pin "bootstrap", to: "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" # @5.3.3
 # pin "@popperjs/core", to: "https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.11.8/umd/popper.min.js" # @2.11.8

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,7 +14,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w( 
-  bootstrap.min.js
+  bootstrap.bundle.min.js
   cocoon.js
   top.css
   index.css


### PR DESCRIPTION
## 概要
前回のバグ修正を本番に適用すると動かなかったので、もう一度修正。cocoonでエラーが起きるのでcocoonは一旦読み込まない

## やったこと
- プリコンパイルされるbootstrap.min.jsをbootstrap.bundle.min.jsに変えた
- cocoonの読み込み一旦削除

## やってないこと

## 課題・疑問点
