### PR TITLE
本番環境で内窓情報追加できないバグ修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,8 +67,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
@@ -129,7 +129,6 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     fog-aws (3.23.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -206,7 +205,7 @@ GEM
       bigdecimal (~> 3.1)
     net-http (0.4.1)
       uri
-    net-imap (0.4.13)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -217,8 +216,6 @@ GEM
       net-protocol
     nio4r (2.7.3)
     nokogiri (1.16.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -258,7 +255,7 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    public_suffix (5.1.1)
+    public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -376,7 +373,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
-  x86_64-linux
 
 DEPENDENCIES
   action_args

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -9,13 +9,16 @@ class InnerSashesController < ApplicationController
                                           :new_comfirmation]
 
   def new_step2
+    # fields_forを使わないのはinner_sashのフォームは一つにしたいため
     @inner_sash = InnerSash.new
     @site_memo.update_status(action: action_name)
   end
 
   def new_append_room
-    @inner_sash = InnerSash.new(inner_sash_params.merge(site_memo_id: @site_memo.id))
-    @inner_sash = InnerSash.new if @inner_sash.save
+    inner_sash = @site_memo.inner_sashes.build(inner_sash_params_emergency)
+    # @inner_sash = InnerSash.new(inner_sash_params.merge(site_memo_id: @site_memo.id))
+    @inner_sash = InnerSash.new if inner_sash.save
+    # 保存失敗したら、パラメーターを元に作ったインスタンス返す
   end
 
   def new_step3
@@ -95,6 +98,12 @@ private
                                       :sash_type, :color, :number_of_shoji, :hanging_origin, :is_flat_bar, :is_adjust, 
                                       :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height,
                                       :template, photos_attributes: [:id, :file_name, :_destroy])
+  end
+
+  def inner_sash_params_emergency
+    params.require(:inner_sash).permit(:room, :width_up_size, :width_down_size, :width_middle_size, 
+                                       :height_left_size, :height_middle_size, :height_right_size,
+                                       :width_frame_depth, :height_frame_depth)
   end
 
   def site_memo_params

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
-    <%# <%= javascript_pack_tag 'application', 'data-turbo-track': 'reload' %>
+
     <%= javascript_importmap_tags %>
     <%= yield(:js) %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,7 +15,6 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w( 
   bootstrap.bundle.min.js
-  cocoon.js
   top.css
   index.css
   show.css


### PR DESCRIPTION
## 概要
本番環境で内窓情報が追加できないバグの修正。
本番で動くかどうかわからないので試してダメならまた修正

## やったこと
- new_append_roomの挙動変更

## やってないこと

## 課題・疑問点

