### PR TITLE
内窓詳細ページ部屋名編集機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@
 yarn-debug.log*
 .yarn-integrity
 /.env
-config/settings.yml
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     fog-aws (3.23.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -216,6 +217,8 @@ GEM
       net-protocol
     nio4r (2.7.3)
     nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -373,6 +376,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   action_args

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -42,3 +42,17 @@
   max-width: 60%;
   max-height: 60%;
 }
+
+.btn-ordered{
+  color: var(--main-back);
+  background-color: var(--main);
+  border: none;
+  box-shadow: 0 2px 1px 1px var(--character);
+}
+
+.btn-unordered{
+  color: var(--main-back);
+  background-color: var(--sign);
+  border: none;
+  box-shadow: 0 2px 1px 1px var(--character);
+}

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -101,6 +101,13 @@ private
                                       :template, photos_attributes: [:id, :file_name, :_destroy])
   end
 
+  #緊急用後でリファクタリング
+  def inner_sash_params_emergency
+    params.require(:inner_sash).permit(:room, :width_up_size, :width_down_size, :width_middle_size, 
+                                       :height_left_size, :height_middle_size, :height_right_size,
+                                       :width_frame_depth, :height_frame_depth)
+  end
+
   def site_memo_params
     params.require(:site_memo).permit(:remark, inner_sashes_attributes: [:id, :room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -96,8 +96,8 @@ private
     params.require(:inner_sash).permit(:room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,
                                       :sash_type, :color, :number_of_shoji, :hanging_origin, :is_flat_bar, :is_adjust, 
-                                      :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height,
-                                      :template, photos_attributes: [:id, :file_name, :_destroy])
+                                      :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height)
+                                      # :template,photos_attributes: [:id, :file_name, :_destroy]
   end
 
   def site_memo_params

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -94,9 +94,9 @@ class InnerSashesController < ApplicationController
     @inner_sash.update!(inner_sash_params)
 
     # templateはbasic_info、shoji_and_glass、photo_and_othersのどれか
-    template = inner_sash_params[:template]
-    flash.now.notice = I18n.t("inner_sashes.update.#{template}") + "を更新しました"
-    render "#{template}", content_type: 'text/vnd.turbo-stream.html'
+    @template = inner_sash_params[:template]
+    flash.now.notice = I18n.t("inner_sashes.update.#{@template}") + "を更新しました"
+    render "#{@template}", content_type: 'text/vnd.turbo-stream.html'
   end
 
 private

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -101,6 +101,7 @@ private
                                       :template, photos_attributes: [:id, :file_name, :_destroy])
   end
 
+<<<<<<< HEAD
   #緊急用後でリファクタリング
   def inner_sash_params_emergency
     params.require(:inner_sash).permit(:room, :width_up_size, :width_down_size, :width_middle_size, 
@@ -108,6 +109,8 @@ private
                                        :width_frame_depth, :height_frame_depth)
   end
 
+=======
+>>>>>>> e1ef9c2 (ログの出力設定)
   def site_memo_params
     params.require(:site_memo).permit(:remark, inner_sashes_attributes: [:id, :room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -101,22 +101,6 @@ private
                                       :template, photos_attributes: [:id, :file_name, :_destroy])
   end
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 5b33e53 (コンフリクト解消)
-  #緊急用後でリファクタリング
-  def inner_sash_params_emergency
-    params.require(:inner_sash).permit(:room, :width_up_size, :width_down_size, :width_middle_size, 
-                                       :height_left_size, :height_middle_size, :height_right_size,
-                                       :width_frame_depth, :height_frame_depth)
-  end
-
-<<<<<<< HEAD
-=======
->>>>>>> e1ef9c2 (ログの出力設定)
-=======
->>>>>>> 5b33e53 (コンフリクト解消)
   def site_memo_params
     params.require(:site_memo).permit(:remark, inner_sashes_attributes: [:id, :room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -15,11 +15,10 @@ class InnerSashesController < ApplicationController
   end
 
   def new_append_room
+    p @site_memo.id
     @inner_sash = InnerSash.new(inner_sash_params.merge(site_memo_id: @site_memo.id))
     @inner_sash = InnerSash.new if @inner_sash.save
     # 保存失敗したら、パラメーターを元に作ったインスタンス返す
-  rescue => e
-    logger.error(e.message)
   end
 
   def new_step3
@@ -114,6 +113,7 @@ private
 
   def set_site_memo
     @site_memo = SiteMemo.find_by(kind: 'inner_sash', site_id: session[:site_id])
+    p @site_memo
   end
 
   def correct_inner_sash(id:)

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -15,8 +15,8 @@ class InnerSashesController < ApplicationController
   end
 
   def new_append_room
-    p @site_memo.id
-    @inner_sash = InnerSash.new(inner_sash_params.merge(site_memo_id: @site_memo.id))
+    @inner_sash = @site_memo.inner_sashes.build(inner_sash_params)
+    p @inner_sash
     @inner_sash = InnerSash.new if @inner_sash.save
     # 保存失敗したら、パラメーターを元に作ったインスタンス返す
   end
@@ -113,7 +113,6 @@ private
 
   def set_site_memo
     @site_memo = SiteMemo.find_by(kind: 'inner_sash', site_id: session[:site_id])
-    p @site_memo
   end
 
   def correct_inner_sash(id:)

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -15,9 +15,8 @@ class InnerSashesController < ApplicationController
   end
 
   def new_append_room
-    inner_sash = @site_memo.inner_sashes.build(inner_sash_params)
-    @inner_sash = InnerSash.new if inner_sash.save
-    @inner_sash = inner_sash
+    @inner_sash = InnerSash.new(inner_sash_params.merge(site_memo_id: @site_memo.id))
+    @inner_sash = InnerSash.new if @inner_sash.save
     # 保存失敗したら、パラメーターを元に作ったインスタンス返す
   end
 

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -75,7 +75,7 @@ class InnerSashesController < ApplicationController
 
   def switch(template:, id:)
      # templateはbasic_info、shoji_and_glass、photo_and_others
-     # h_cross_drawing w_cross_drawing　のどれか
+     # h_cross_drawing w_cross_drawing　edit_roomのどれか
     # render "#{template}", content_type: 'text/vnd.turbo-stream.html'
     render "#{template}"
   end

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -1,6 +1,6 @@
 class InnerSashesController < ApplicationController
   before_action :authenticate_user!
-  before_action :correct_inner_sash, only: [:show, :switch, :navigate_page, :update_order, :update]
+  before_action :correct_inner_sash, only: [:show, :switch, :navigate_page, :update_order, :edit, :update]
   before_action :set_site_memo, only: [:new_step2, :new_step3, :new_step4, :new_step5,
                                        :new_append_room, :new_append_shoji_and_glass, 
                                        :new_append_photo_and_others, :new_append_basic_info, :new_comfirmation]
@@ -81,7 +81,7 @@ class InnerSashesController < ApplicationController
   end
 
   def edit(id:)
-
+    
   end
 
   def update(id:)

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -102,6 +102,9 @@ private
   end
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 5b33e53 (コンフリクト解消)
   #緊急用後でリファクタリング
   def inner_sash_params_emergency
     params.require(:inner_sash).permit(:room, :width_up_size, :width_down_size, :width_middle_size, 
@@ -109,8 +112,11 @@ private
                                        :width_frame_depth, :height_frame_depth)
   end
 
+<<<<<<< HEAD
 =======
 >>>>>>> e1ef9c2 (ログの出力設定)
+=======
+>>>>>>> 5b33e53 (コンフリクト解消)
   def site_memo_params
     params.require(:site_memo).permit(:remark, inner_sashes_attributes: [:id, :room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -1,6 +1,6 @@
 class InnerSashesController < ApplicationController
   before_action :authenticate_user!
-  before_action :correct_inner_sash, only: [:show, :switch, :navigate_page, :update_order, :edit, :update]
+  before_action :correct_inner_sash, only: [:show, :switch, :navigate_page, :update_order, :edit_room, :update]
   before_action :set_site_memo, only: [:new_step2, :new_step3, :new_step4, :new_step5,
                                        :new_append_room, :new_append_shoji_and_glass, 
                                        :new_append_photo_and_others, :new_append_basic_info, :new_comfirmation]
@@ -80,8 +80,8 @@ class InnerSashesController < ApplicationController
     render "#{template}"
   end
 
-  def edit(id:)
-    
+  def edit_room(id:)
+
   end
 
   def update(id:)

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -54,6 +54,7 @@ class InnerSashesController < ApplicationController
   def show(id:)
     @inner_sash = InnerSash.preload(site_memo: :site).find(id)
     @order_key = get_opposite_order_key(inner_sash: @inner_sash)
+    @template = 'basic_info'
   end
 
   def update_order(id:, order:)
@@ -68,15 +69,17 @@ class InnerSashesController < ApplicationController
     redirect_to site_memos_index_path(site_id: inner_sash.site_memo.site_id), notice: "メモを削除しました"
   end
 
-  def navigate_page(id:)
+  def navigate_page(id:, template:)
     @inner_sash = InnerSash.preload(site_memo: :site).find(id.to_i)
     @order_key = get_opposite_order_key(inner_sash: @inner_sash)
+    @template = template
   end
 
   def switch(template:, id:)
      # templateはbasic_info、shoji_and_glass、photo_and_others
      # h_cross_drawing w_cross_drawing　edit_roomのどれか
     # render "#{template}", content_type: 'text/vnd.turbo-stream.html'
+    @template = template
     render "#{template}"
   end
 

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -15,9 +15,9 @@ class InnerSashesController < ApplicationController
   end
 
   def new_append_room
-    @inner_sash = @site_memo.inner_sashes.build(inner_sash_params)
-    p @inner_sash
-    @inner_sash = InnerSash.new if @inner_sash.save
+    inner_sash = @site_memo.inner_sashes.build(inner_sash_params)
+    @inner_sash = InnerSash.new if inner_sash.save
+    @inner_sash = inner_sash
     # 保存失敗したら、パラメーターを元に作ったインスタンス返す
   end
 
@@ -96,8 +96,8 @@ private
     params.require(:inner_sash).permit(:room, :number_of_shoji, :width_up_size, :width_down_size, :width_middle_size, 
                                       :height_left_size, :height_middle_size, :height_right_size, :width_frame_depth, :height_frame_depth,
                                       :sash_type, :color, :number_of_shoji, :hanging_origin, :is_flat_bar, :is_adjust, 
-                                      :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height)
-                                      # :template,photos_attributes: [:id, :file_name, :_destroy]
+                                      :glass_thickness, :glass_kind, :glass_color, :is_low_e, :key_height, :middle_frame_height,
+                                      :template, photos_attributes: [:id, :file_name, :_destroy])
   end
 
   def site_memo_params

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -80,6 +80,10 @@ class InnerSashesController < ApplicationController
     render "#{template}"
   end
 
+  def edit(id:)
+
+  end
+
   def update(id:)
     @inner_sash.update!(inner_sash_params)
 

--- a/app/controllers/inner_sashes_controller.rb
+++ b/app/controllers/inner_sashes_controller.rb
@@ -55,6 +55,7 @@ class InnerSashesController < ApplicationController
     @inner_sash = InnerSash.preload(site_memo: :site).find(id)
     @order_key = get_opposite_order_key(inner_sash: @inner_sash)
     @template = 'basic_info'
+    @draw_temp = 'opening_drawing'
   end
 
   def update_order(id:, order:)
@@ -73,12 +74,14 @@ class InnerSashesController < ApplicationController
     @inner_sash = InnerSash.preload(site_memo: :site).find(id.to_i)
     @order_key = get_opposite_order_key(inner_sash: @inner_sash)
     @template = template
+    @draw_temp = 'opening_drawing'
   end
 
   def switch(template:, id:)
      # templateはbasic_info、shoji_and_glass、photo_and_others
-     # h_cross_drawing w_cross_drawing　edit_roomのどれか
+     # h_cross_drawing w_cross_drawing edit_roomのどれか
     # render "#{template}", content_type: 'text/vnd.turbo-stream.html'
+    @draw_temp = template
     @template = template
     render "#{template}"
   end

--- a/app/helpers/inner_sashes_helper.rb
+++ b/app/helpers/inner_sashes_helper.rb
@@ -8,7 +8,7 @@ module InnerSashesHelper
     return 0
   end
 
-  def is_active(tab_name)
-    return 'active' if tab_name.present?
+  def is_active(template, compare)
+    return 'active' if template == compare 
   end
 end

--- a/app/helpers/inner_sashes_helper.rb
+++ b/app/helpers/inner_sashes_helper.rb
@@ -8,7 +8,7 @@ module InnerSashesHelper
     return 0
   end
 
-  def is_active(template, compare)
-    return 'active' if template == compare 
+  def is_active(template, compare_temp)
+    return 'active' if template == compare_temp 
   end
 end

--- a/app/views/inner_sashes/_basic_info.html.erb
+++ b/app/views/inner_sashes/_basic_info.html.erb
@@ -37,7 +37,7 @@
       <div class="row g-0 mt-4 mt-md-5 align-items-center">
         <div class="col-3 mb-5">
           <% if @inner_sash.previous.present? %>
-            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous, template: 'basic_info'), data: {turbo_method: :post} do %>
               <i class="bi bi-arrow-left-circle-fill h1"></i>
             <% end %>
           <% end %>
@@ -47,7 +47,7 @@
         </div>
         <div class="col-3 mb-5">
           <% if @inner_sash.next.present? %>
-            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next, template: 'basic_info'), data: {turbo_method: :post}, class: 'd-block h-100' do %>
               <i class="bi bi-arrow-right-circle-fill h1"></i>
             <% end %>
           <% end %>

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,14 +1,14 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link",
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link #{is_active(@draw_temp, 'opening_drawing')}",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: "nav-link",
+    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: "nav-link #{is_active(@draw_temp, 'h_cross_drawing')}",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: "nav-link", 
+    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: "nav-link #{is_active(@draw_temp, 'w_cross_drawing')}", 
         data: { turbo_stream: true } %>
   </li>
 </ul>

--- a/app/views/inner_sashes/_drawing_tabs.html.erb
+++ b/app/views/inner_sashes/_drawing_tabs.html.erb
@@ -1,14 +1,14 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? opening)}",
+    <%= link_to '開口図', inner_sashes_switch_path(template: 'opening_drawing', id: inner_sash.id), class: "nav-link",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? h_cross)}",
+    <%= link_to '縦断面', inner_sashes_switch_path(template: 'h_cross_drawing', id: inner_sash.id), class: "nav-link",
         data: { turbo_stream: true } %>
   </li>
   <li class="nav-item">
-    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: "nav-link #{is_active(defined? w_cross)}", 
+    <%= link_to '横断面', inner_sashes_switch_path(template: 'w_cross_drawing', id: inner_sash.id), class: "nav-link", 
         data: { turbo_stream: true } %>
   </li>
 </ul>

--- a/app/views/inner_sashes/_order_link.html.erb
+++ b/app/views/inner_sashes/_order_link.html.erb
@@ -3,5 +3,5 @@
     data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>
 
 <%= link_to "#{InnerSash.orders_i18n[order_key.to_sym]}にする",
-    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-none d-lg-inline btn btn-primary py-1 px-3",
+    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-none d-lg-inline btn btn-#{order_key} py-1 px-3",
     data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>

--- a/app/views/inner_sashes/_order_link.html.erb
+++ b/app/views/inner_sashes/_order_link.html.erb
@@ -2,6 +2,6 @@
     inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-lg-none",
     data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>
 
-    <%= link_to "#{InnerSash.orders_i18n[order_key.to_sym]}にする",
-    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-none d-lg-inline btn btn-primary py-0 px-3",
+<%= link_to "#{InnerSash.orders_i18n[order_key.to_sym]}にする",
+    inner_sashes_update_order_path(id: inner_sash.id, order: order_key), class: "d-none d-lg-inline btn btn-primary py-1 px-3",
     data: {turbo_method: :post, turbo_confirm: "#{InnerSash.orders_i18n[order_key.to_sym]}にしますか？"} %>

--- a/app/views/inner_sashes/_photo_and_others.html.erb
+++ b/app/views/inner_sashes/_photo_and_others.html.erb
@@ -24,7 +24,7 @@
       <div class="row g-0 mt-4 align-items-center">
         <div class="col-3 mb-5">
           <% if @inner_sash.previous.present? %>
-            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous, template: 'photo_and_others'), data: {turbo_method: :post} do %>
               <i class="bi bi-arrow-left-circle-fill h1"></i>
             <% end %>
           <% end %>
@@ -34,7 +34,7 @@
         </div>
         <div class="col-3 mb-5">
           <% if @inner_sash.next.present? %>
-            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next, template: 'photo_and_others'), data: {turbo_method: :post}, class: 'd-block h-100' do %>
               <i class="bi bi-arrow-right-circle-fill h1"></i>
             <% end %>
           <% end %>

--- a/app/views/inner_sashes/_shoji_and_glass.html.erb
+++ b/app/views/inner_sashes/_shoji_and_glass.html.erb
@@ -29,7 +29,7 @@
       <div class="row g-0 mt-4 mt-md-5 align-items-center">
         <div class="col-3 mb-5">
           <% if @inner_sash.previous.present? %>
-            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous), data: {turbo_method: :post} do %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.previous, template: 'shoji_and_glass'), data: {turbo_method: :post} do %>
               <i class="bi bi-arrow-left-circle-fill h1"></i>
             <% end %>
           <% end %>
@@ -39,7 +39,7 @@
         </div>
         <div class="col-3 mb-5">
           <% if @inner_sash.next.present? %>
-            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next), data: {turbo_method: :post}, class: 'd-block h-100' do %>
+            <%= link_to inner_sashes_navigate_page_path(id: @inner_sash.next, template: 'shoji_and_glass'), data: {turbo_method: :post}, class: 'd-block h-100' do %>
               <i class="bi bi-arrow-right-circle-fill h1"></i>
             <% end %>
           <% end %>

--- a/app/views/inner_sashes/_tabs.html.erb
+++ b/app/views/inner_sashes/_tabs.html.erb
@@ -1,20 +1,20 @@
 <ul class="nav nav-tabs nav-fill">
   <li class='nav-item'>
-    <%= link_to inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), class: "nav-link #{is_active(defined? basic)}",
+    <%= link_to inner_sashes_switch_path(template: 'basic_info', id: @inner_sash.id), class: "nav-link #{is_active(@template, 'basic_info')}",
         data: { turbo_stream: true } do %>
       <p class="d-md-none m-0">寸法</p>
       <p class="d-none d-md-block m-0">基本情報</p>
     <% end %>
   </li>
   <li class='nav-item'>
-    <%= link_to inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id), class: "nav-link #{is_active(defined? shoji)}",
+    <%= link_to inner_sashes_switch_path(template: 'shoji_and_glass', id: @inner_sash.id), class: "nav-link #{is_active(@template, 'shoji_and_glass')}",
         data: { turbo_stream: true } do %>
       <p class="d-md-none m-0">障子</p>
       <p class="d-none d-md-block m-0">障子・ガラス</p>
     <% end %>
   </li>
   <li class='nav-item'>
-    <%= link_to inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id), class: "nav-link #{is_active(defined? photo)}",
+    <%= link_to inner_sashes_switch_path(template: 'photo_and_others', id: @inner_sash.id), class: "nav-link #{is_active(@template, 'photo_and_others')}",
         data: { turbo_stream: true} do %>
       <p class="d-md-none m-0">写真</p>
       <p class="d-none d-md-block m-0">写真・その他</p>

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active'} %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
   <div class="row justify-content-center" style='height:350px;'>
     <%= render 'drawing', inner_sash: @inner_sash %>
   </div>

--- a/app/views/inner_sashes/basic_info.turbo_stream.erb
+++ b/app/views/inner_sashes/basic_info.turbo_stream.erb
@@ -6,6 +6,6 @@
   </div>
 <% end %>
 <%= turbo_stream.update 'inner-sash-data' do %>
-  <%= render 'tabs', basic: 'active' %>
+  <%= render 'tabs' %>
   <%= render 'basic_info', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/edit.turbo_stream.erb
+++ b/app/views/inner_sashes/edit.turbo_stream.erb
@@ -1,0 +1,15 @@
+<%= turbo_stream.update 'room', class: 'col' do %>
+  <%= form_with model: @inner_sash, url: inner_sashes_update_path(@inner_sash.id), class: 'row' do |f| %>
+    <div class="col-8">
+      <%= f.text_field :room, class: 'w-100'  %>
+    </div>
+    <div class="col-4">
+      <%= f.submit "更新", class: 'btn btn-primary px-4 py-0' %>
+    </div>
+  <% end %>
+<% end %>
+<%= turbo_stream.update 'edit-btn' do %>
+  <div>
+    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'edit_cancel', id: @inner_sash.id), class: 'btn btn-secondary px-4 py-0' %>
+  </div>
+<% end %>

--- a/app/views/inner_sashes/edit_room.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_room.turbo_stream.erb
@@ -5,12 +5,12 @@
     </div>
     <%= f.hidden_field :template, value: 'room'  %>
     <div class="col-4">
-      <%= f.submit "更新", class: 'btn btn-primary px-4 py-0' %>
+      <%= f.submit "更新", class: 'btn btn-primary px-3 py-0' %>
     </div>
   <% end %>
 <% end %>
 <%= turbo_stream.update 'edit-btn' do %>
   <div>
-    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'room', id: @inner_sash.id), class: 'btn btn-secondary px-4 py-0', data:{ turbo_stream: true} %>
+    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'room', id: @inner_sash.id), class: 'btn btn-secondary px-1 py-0', data:{ turbo_stream: true} %>
   </div>
 <% end %>

--- a/app/views/inner_sashes/edit_room.turbo_stream.erb
+++ b/app/views/inner_sashes/edit_room.turbo_stream.erb
@@ -3,6 +3,7 @@
     <div class="col-8">
       <%= f.text_field :room, class: 'w-100'  %>
     </div>
+    <%= f.hidden_field :template, value: 'room'  %>
     <div class="col-4">
       <%= f.submit "更新", class: 'btn btn-primary px-4 py-0' %>
     </div>
@@ -10,6 +11,6 @@
 <% end %>
 <%= turbo_stream.update 'edit-btn' do %>
   <div>
-    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'edit_cancel', id: @inner_sash.id), class: 'btn btn-secondary px-4 py-0' %>
+    <%= link_to 'キャンセル', inner_sashes_switch_path(template: 'room', id: @inner_sash.id), class: 'btn btn-secondary px-4 py-0', data:{ turbo_stream: true} %>
   </div>
 <% end %>

--- a/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/h_cross_drawing.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash, h_cross: 'active' %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
   <div class="position-relative">
     <%= image_tag 'h_cross_section.png', class: 'cross-image' %>
     <p class="width-size"><%= @inner_sash.width_frame_depth %></p>

--- a/app/views/inner_sashes/navigate_page.turbo_stream.erb
+++ b/app/views/inner_sashes/navigate_page.turbo_stream.erb
@@ -2,12 +2,14 @@
   <%= render partial: 'order_link', locals: {order_key: @order_key, inner_sash: @inner_sash} %>
 <% end %>
 <%= turbo_stream.update 'inner-sash-delete' do %>
-  <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }%>
+  <%= link_to '削除', inner_sashes_destroy_path(id: @inner_sash.id), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'btn btn-danger px-4 py-0'%>
 <% end %>
 <%= turbo_stream.update 'inner-sash-data-wrap' do %>
   <%= turbo_frame_tag 'drawing' do %>
     <%= render 'drawing_tabs', inner_sash: @inner_sash %>
-    <%= render 'drawing', inner_sash: @inner_sash %>
+    <div class="row justify-content-center" style='height:350px;'>
+      <%= render 'drawing', inner_sash: @inner_sash %>
+    </div>
   <% end %>
   <div id="inner-sash-data" class='mb-3'>
     <%= render 'tabs' %>

--- a/app/views/inner_sashes/navigate_page.turbo_stream.erb
+++ b/app/views/inner_sashes/navigate_page.turbo_stream.erb
@@ -13,6 +13,6 @@
   <% end %>
   <div id="inner-sash-data" class='mb-3'>
     <%= render 'tabs' %>
-    <%= render 'basic_info', inner_sash: @inner_sash %>
+    <%= render @template, inner_sash: @inner_sash %>
   </div>
 <% end %>

--- a/app/views/inner_sashes/opening_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/opening_drawing.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', {inner_sash: @inner_sash, opening: 'active' } %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
   <div class="row justify-content-center" style='height:350px;'>
     <%= render 'drawing', inner_sash: @inner_sash %>
   </div>

--- a/app/views/inner_sashes/photo_and_others.turbo_stream.erb
+++ b/app/views/inner_sashes/photo_and_others.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'inner-sash-data' do %>
-  <%= render 'tabs', photo: 'active' %>
+  <%= render 'tabs' %>
   <%= render 'photo_and_others', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/room.turbo_stream.erb
+++ b/app/views/inner_sashes/room.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream_flash %>
+<%= turbo_stream.update 'room' do %>
+  <p class='m-0'><%= @inner_sash.room %></p>
+<% end %>
+<%= turbo_stream.update 'edit-btn' do %>
+  <div>
+    <%= link_to '編集', inner_sashes_edit_room_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0', data:{ turbo_stream: true} %>
+  </div>
+<% end %>

--- a/app/views/inner_sashes/shoji_and_glass.turbo_stream.erb
+++ b/app/views/inner_sashes/shoji_and_glass.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream_flash %>
 <%= turbo_stream.update 'inner-sash-data' do %>
-  <%= render 'tabs', shoji: 'active' %>  
+  <%= render 'tabs' %>  
   <%= render 'shoji_and_glass', inner_sash: @inner_sash %>
 <% end %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -69,5 +69,5 @@
 <%= stylesheet_link_tag "show", "data-turbo-track": "reload" %>
 
 <% content_for :js do %>
-    <%= javascript_import_module_tag "draw_opening" %>
-  <% end %>
+  <%= javascript_import_module_tag "draw_opening" %>
+<% end %>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -14,6 +14,11 @@
     <div class="col">
       <p class='m-0'>内窓</p>
     </div>
+    <%= turbo_frame_tag 'edit-btn', class: 'col' do %>
+      <div>
+        <%= link_to '編集', inner_sashes_edit_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0', data:{ turbo_stream: true} %>
+      </div>
+    <% end %>
     <div class="col-2 d-none d-sm-block">
       <%= turbo_frame_tag 'order-pc' do %>
         <div class="badge <%= @inner_sash.order %>-label py-1 px-3">
@@ -21,11 +26,6 @@
         </div>
       <% end %>
     </div>
-    <%= turbo_frame_tag 'edit-btn', class: 'col' do %>
-      <div>
-        <%= link_to '編集', inner_sashes_edit_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0', data:{ turbo_stream: true} %>
-      </div>
-    <% end %>
     <div class="col-1 p-0 dropdown d-lg-none">
       <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
         <i class="bi bi-three-dots-vertical h1"></i>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -22,7 +22,7 @@
       <% end %>
     </div>
     <div class="col">
-      <%= link_to '編集', 'javascript:void(0)', class: 'btn btn-primary px-4 py-0' %>
+      <%= link_to '編集', inner_sashes_edit_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0' %>
     </div>
     <div class="col-1 p-0 dropdown d-lg-none">
       <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <%= turbo_frame_tag 'edit-btn', class: 'col' do %>
       <div>
-        <%= link_to '編集', inner_sashes_edit_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0', data:{ turbo_stream: true} %>
+        <%= link_to '編集', inner_sashes_edit_room_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0', data:{ turbo_stream: true} %>
       </div>
     <% end %>
     <div class="col-2 d-none d-sm-block">

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -60,8 +60,8 @@
       </div>
     <% end %>
     <%= turbo_frame_tag 'inner-sash-data' do %>
-      <%= render 'tabs', basic: 'active' %>
-      <%= render 'basic_info', inner_sash: @inner_sash%>
+      <%= render 'tabs' %>
+      <%= render 'basic_info', inner_sash: @inner_sash %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/inner_sashes/show.html.erb
+++ b/app/views/inner_sashes/show.html.erb
@@ -8,9 +8,9 @@
     </div>
   </div>
   <div class="row align-items-center text-center mb-3" style='height:60px;'>
-    <div class="col">
+    <%= turbo_frame_tag 'room', class: 'col' do %>
       <p class='m-0'><%= @inner_sash.room %></p>
-    </div>
+    <% end %>
     <div class="col">
       <p class='m-0'>内窓</p>
     </div>
@@ -21,9 +21,11 @@
         </div>
       <% end %>
     </div>
-    <div class="col">
-      <%= link_to '編集', inner_sashes_edit_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0' %>
-    </div>
+    <%= turbo_frame_tag 'edit-btn', class: 'col' do %>
+      <div>
+        <%= link_to '編集', inner_sashes_edit_path(@inner_sash.id), class: 'btn btn-primary px-4 py-0', data:{ turbo_stream: true} %>
+      </div>
+    <% end %>
     <div class="col-1 p-0 dropdown d-lg-none">
       <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
         <i class="bi bi-three-dots-vertical h1"></i>

--- a/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
+++ b/app/views/inner_sashes/w_cross_drawing.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.update 'drawing' do %>
-  <%= render 'drawing_tabs', inner_sash: @inner_sash, w_cross: 'active' %>
+  <%= render 'drawing_tabs', inner_sash: @inner_sash %>
   <div class="position-relative">
     <%= image_tag 'w_cross_section.png', class: 'cross-image'%>
     <p class='height-size'><%= @inner_sash.height_frame_depth %></p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -107,6 +107,7 @@ ja:
       basic_info: "基本情報"
       shoji_and_glass: "障子・ガラス"
       photo_and_others: "写真・その他"
+      room: "部屋名"
 
   date:
     abbr_day_names:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   get 'inner_sashes/new_comfirmation'
   get 'inner_sashes/show/:id', to: 'inner_sashes#show', as: :inner_sashes_show
   delete 'inner_sashes/destroy/:id', to: 'inner_sashes#destroy', as: :inner_sashes_destroy
-  post 'inner_sashes/navigate_page/:id', to:'inner_sashes#navigate_page', as: :inner_sashes_navigate_page
+  post 'inner_sashes/navigate_page/:id/:template', to:'inner_sashes#navigate_page', as: :inner_sashes_navigate_page
   get 'inner_sashes/edit_room/:id', to: 'inner_sashes#edit_room', as: :inner_sashes_edit_room
   post 'inner_sashes/update_order/:id/:order', to: 'inner_sashes#update_order', as: :inner_sashes_update_order
   get 'inner_sashes/switch/:template/:id', to: 'inner_sashes#switch', as: :inner_sashes_switch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get 'inner_sashes/show/:id', to: 'inner_sashes#show', as: :inner_sashes_show
   delete 'inner_sashes/destroy/:id', to: 'inner_sashes#destroy', as: :inner_sashes_destroy
   post 'inner_sashes/navigate_page/:id', to:'inner_sashes#navigate_page', as: :inner_sashes_navigate_page
+  get 'inner_sashes/edit/:id', to: 'inner_sashes#edit', as: :inner_sashes_edit
   post 'inner_sashes/update_order/:id/:order', to: 'inner_sashes#update_order', as: :inner_sashes_update_order
   get 'inner_sashes/switch/:template/:id', to: 'inner_sashes#switch', as: :inner_sashes_switch
   patch 'inner_sashes/update/:id', to: 'inner_sashes#update', as: :inner_sashes_update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get 'inner_sashes/show/:id', to: 'inner_sashes#show', as: :inner_sashes_show
   delete 'inner_sashes/destroy/:id', to: 'inner_sashes#destroy', as: :inner_sashes_destroy
   post 'inner_sashes/navigate_page/:id', to:'inner_sashes#navigate_page', as: :inner_sashes_navigate_page
-  get 'inner_sashes/edit/:id', to: 'inner_sashes#edit', as: :inner_sashes_edit
+  get 'inner_sashes/edit_room/:id', to: 'inner_sashes#edit_room', as: :inner_sashes_edit_room
   post 'inner_sashes/update_order/:id/:order', to: 'inner_sashes#update_order', as: :inner_sashes_update_order
   get 'inner_sashes/switch/:template/:id', to: 'inner_sashes#switch', as: :inner_sashes_switch
   patch 'inner_sashes/update/:id', to: 'inner_sashes#update', as: :inner_sashes_update

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+limit_size:
+  digits: 5
+child:
+  none: 0


### PR DESCRIPTION
## 概要
内窓詳細ページで部屋名の編集を可能にした。
タブのアクティブ化の処理を変更し、ターブストリーム後もタブがアクティブになるように設定

## やったこと
- 部屋名を編集可能に
- タブのアクティブ化の方法変更
- 内窓ページ切り替えしてもタブのアクティブが変わらないように設定

## やってないこと
- 一部、ターボストリーム後のタブの挙動

## 課題・疑問点
- タブ切り替えのアクティブ化をもう少し保守性をいしきしたい。その方法考える


その他場合によって```UI before/after``` ```注意事項``` ```備考``` ```どうやるのか```など追加
